### PR TITLE
Clippy Lints

### DIFF
--- a/crypto/musig/src/lib.rs
+++ b/crypto/musig/src/lib.rs
@@ -171,7 +171,7 @@ pub mod rng_adapt {
         fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
             self.0
                 .try_fill_bytes(dest)
-                .map_err(|e| secp256kfun::rand_core::Error::new(e))
+                .map_err(secp256kfun::rand_core::Error::new)
         }
     }
 }

--- a/crypto/tbs/src/hash.rs
+++ b/crypto/tbs/src/hash.rs
@@ -4,7 +4,7 @@ use rand_chacha::ChaChaRng;
 use sha3::digest::generic_array::typenum::U32;
 use sha3::Digest;
 
-const HASH_TAG: &'static [u8] = b"TBS_BLS12-381_";
+const HASH_TAG: &[u8] = b"TBS_BLS12-381_";
 
 pub fn hash_bytes_to_curve<G: Group>(data: &[u8]) -> G {
     let mut hash_engine = sha3::Sha3_256::new();

--- a/crypto/tbs/src/lib.rs
+++ b/crypto/tbs/src/lib.rs
@@ -99,7 +99,7 @@ point_impl!(BlindedSignature);
 point_impl!(BlindedSignatureShare);
 
 impl SecretKeyShare {
-    pub fn to_pub_key_share(&self) -> PublicKeyShare {
+    pub fn to_pub_key_share(self) -> PublicKeyShare {
         PublicKeyShare((G2Projective::generator() * self.0).to_affine())
     }
 }

--- a/crypto/tbs/src/lib.rs
+++ b/crypto/tbs/src/lib.rs
@@ -39,19 +39,19 @@ pub struct AggregatePublicKey(#[serde(with = "serde_impl::g2")] pub G2Affine);
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BlindingKey(#[serde(with = "serde_impl::scalar")] pub Scalar);
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct BlindedMessage(#[serde(with = "serde_impl::g1")] pub G1Affine);
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct BlindedSignatureShare(#[serde(with = "serde_impl::g1")] pub G1Affine);
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct BlindedSignature(#[serde(with = "serde_impl::g1")] pub G1Affine);
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct Signature(#[serde(with = "serde_impl::g1")] pub G1Affine);
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct Message(#[serde(with = "serde_impl::g1")] pub G1Affine);
 
 pub trait FromRandom {
@@ -89,6 +89,14 @@ macro_rules! point_impl {
                 self.0.to_compressed()
             }
         }
+
+        impl PartialEq for $type {
+            fn eq(&self, other: &$type) -> bool {
+                self.0 == other.0
+            }
+        }
+
+        impl Eq for $type {}
     };
 }
 

--- a/crypto/tbs/src/poly.rs
+++ b/crypto/tbs/src/poly.rs
@@ -53,7 +53,7 @@ where
 {
     let elements_closure = elements.clone();
     let lagrange_coefficient = move |i: usize| -> S {
-        let xi = elements_closure.clone().skip(i).next().unwrap().0;
+        let xi = elements_closure.clone().nth(i).unwrap().0;
 
         elements_closure
             .clone()

--- a/minimint-api/src/db/batch.rs
+++ b/minimint-api/src/db/batch.rs
@@ -85,6 +85,12 @@ impl<T> Accumulator<T> {
     }
 }
 
+impl<T> Default for Accumulator<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a, T> AccumulatorTx<'a, T> {
     /// Commit the current accumulator state
     pub fn commit(self) {

--- a/minimint-api/src/db/mod.rs
+++ b/minimint-api/src/db/mod.rs
@@ -190,7 +190,7 @@ where
                 };
                 Some(Ok((key, value)))
             }
-            Err(e) => Some(Err(e.into())),
+            Err(e) => Some(Err(e)),
         }
     }
 }

--- a/minimint-api/src/encoding/mod.rs
+++ b/minimint-api/src/encoding/mod.rs
@@ -45,8 +45,7 @@ macro_rules! impl_encode_decode_num {
                 mut d: D,
             ) -> Result<Self, crate::encoding::DecodeError> {
                 let mut bytes = [0u8; (<$num_type>::BITS / 8) as usize];
-                d.read_exact(&mut bytes)
-                    .map_err(|e| DecodeError::from_err(e))?;
+                d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
                 Ok(<$num_type>::from_le_bytes(bytes))
             }
         }

--- a/minimint-api/src/keys.rs
+++ b/minimint-api/src/keys.rs
@@ -37,7 +37,7 @@ impl ToPublicKey for CompressedPublicKey {
     fn to_public_key(&self) -> PublicKey {
         PublicKey {
             compressed: true,
-            key: self.key.clone(),
+            key: self.key,
         }
     }
 

--- a/minimint-api/src/lib.rs
+++ b/minimint-api/src/lib.rs
@@ -507,7 +507,7 @@ where
         for _ in 0..len {
             let amt = Amount::consensus_decode(&mut d)?;
             let coin = C::consensus_decode(&mut d)?;
-            coins.entry(amt).or_insert(Vec::new()).push(coin);
+            coins.entry(amt).or_insert_with(Vec::new).push(coin);
         }
         Ok(Coins { coins })
     }

--- a/minimint-api/src/lib.rs
+++ b/minimint-api/src/lib.rs
@@ -524,8 +524,7 @@ impl Encodable for TransactionId {
 impl Decodable for TransactionId {
     fn consensus_decode<D: std::io::Read>(mut d: D) -> Result<Self, DecodeError> {
         let mut bytes = [0u8; 32];
-        d.read_exact(&mut bytes)
-            .map_err(|e| DecodeError::from_err(e))?;
+        d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
         Ok(TransactionId::from_inner(bytes))
     }
 }

--- a/minimint-api/src/txoproof.rs
+++ b/minimint-api/src/txoproof.rs
@@ -197,14 +197,13 @@ impl<'de> Deserialize<'de> for TxOutProof {
     {
         if deserializer.is_human_readable() {
             let hex_str: &str = Deserialize::deserialize(deserializer)?;
-            let bytes =
-                hex::decode(hex_str).map_err(|e| <D as Deserializer<'de>>::Error::custom(e))?;
+            let bytes = hex::decode(hex_str).map_err(<D as Deserializer<'de>>::Error::custom)?;
             Ok(TxOutProof::consensus_decode(Cursor::new(bytes))
-                .map_err(|e| <D as Deserializer<'de>>::Error::custom(e))?)
+                .map_err(<D as Deserializer<'de>>::Error::custom)?)
         } else {
             let bytes: &[u8] = Deserialize::deserialize(deserializer)?;
             Ok(TxOutProof::consensus_decode(Cursor::new(bytes))
-                .map_err(|e| <D as Deserializer<'de>>::Error::custom(e))?)
+                .map_err(<D as Deserializer<'de>>::Error::custom)?)
         }
     }
 }

--- a/minimint-api/src/txoproof.rs
+++ b/minimint-api/src/txoproof.rs
@@ -26,7 +26,7 @@ pub struct PegInProof {
     tweak_contract_key: musig::PubKey,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct TxOutProof {
     block_header: BlockHeader,
     merkle_proof: PartialMerkleTree,
@@ -243,6 +243,14 @@ impl Hash for TxOutProof {
         state.write(&bytes);
     }
 }
+
+impl PartialEq for TxOutProof {
+    fn eq(&self, other: &TxOutProof) -> bool {
+        self.block_header == other.block_header && self.merkle_proof == other.merkle_proof
+    }
+}
+
+impl Eq for TxOutProof {}
 
 impl Decodable for PegInProof {
     fn consensus_decode<D: std::io::Read>(mut d: D) -> Result<Self, DecodeError> {

--- a/minimint-api/src/txoproof.rs
+++ b/minimint-api/src/txoproof.rs
@@ -112,8 +112,8 @@ impl PegInProof {
         Ok(PegInProof {
             txout_proof,
             transaction,
-            tweak_contract_key,
             output_idx,
+            tweak_contract_key,
         })
     }
 

--- a/minimint-api/src/util.rs
+++ b/minimint-api/src/util.rs
@@ -13,7 +13,7 @@ impl<'a, I, C> TieredMultiZip<'a, I, C> {
     /// Creates a new MultiZip Iterator from `Coins` iterators. These have to be checked for
     /// structural equality! There also has to be at least one iterator in the `iter` vector.
     pub fn new(iters: Vec<I>) -> Self {
-        assert!(iters.len() >= 1);
+        assert!(!iters.is_empty());
 
         TieredMultiZip {
             iters,

--- a/minimint/src/bin/configgen.rs
+++ b/minimint/src/bin/configgen.rs
@@ -24,7 +24,7 @@ fn main() {
     } = StructOpt::from_args();
     let mut rng = OsRng::new().unwrap();
 
-    let peers = (0..nodes).map(|id| PeerId::from(id)).collect::<Vec<_>>();
+    let peers = (0..nodes).map(PeerId::from).collect::<Vec<_>>();
     let max_evil = hbbft::util::max_faulty(peers.len());
     println!(
         "Generating keys such that up to {} peers may fail/be evil",
@@ -47,7 +47,7 @@ fn main() {
         serde_json::to_writer_pretty(file, &cfg).unwrap();
     }
 
-    let mut client_cfg_file_path: PathBuf = cfg_path.clone();
+    let mut client_cfg_file_path: PathBuf = cfg_path;
     client_cfg_file_path.push("client.json");
     let client_cfg_file =
         std::fs::File::create(client_cfg_file_path).expect("Could not create cfg file");

--- a/minimint/src/config.rs
+++ b/minimint/src/config.rs
@@ -82,7 +82,7 @@ impl GenerateConfig for ServerConfig {
                 let peer = Peer {
                     hbbft_port: params.hbbft_base_port + id_u16,
                     api_port: params.api_base_port + id_u16,
-                    hbbft_pk: netinf.public_key(&id).unwrap().clone(),
+                    hbbft_pk: *netinf.public_key(&id).unwrap(),
                 };
 
                 (id, peer)

--- a/minimint/src/consensus/mod.rs
+++ b/minimint/src/consensus/mod.rs
@@ -202,14 +202,14 @@ where
                     .consensus_proposal(self.rng_gen.get_rng())
                     .await
                     .into_iter()
-                    .map(|wci| ConsensusItem::Wallet(wci)),
+                    .map(ConsensusItem::Wallet),
             )
             .chain(
                 self.mint
                     .consensus_proposal(self.rng_gen.get_rng())
                     .await
                     .into_iter()
-                    .map(|mci| ConsensusItem::Mint(mci)),
+                    .map(ConsensusItem::Mint),
             )
             .collect()
     }

--- a/minimint/src/lib.rs
+++ b/minimint/src/lib.rs
@@ -91,10 +91,7 @@ pub async fn run_minimint(cfg: ServerConfig) {
                 .contributions
                 .values()
                 .flatten()
-                .filter(|ci| match ci {
-                    ConsensusItem::Wallet(_) => false,
-                    _ => true,
-                })
+                .filter(|ci| !matches!(ci, ConsensusItem::Wallet(_)))
                 .collect::<HashSet<_>>();
 
             let full_proposal = proposal.take().expect("Is always refilled");

--- a/minimint/src/lib.rs
+++ b/minimint/src/lib.rs
@@ -146,7 +146,7 @@ async fn spawn_hbbft(
             cfg.hbbft_sk.inner().clone(),
             cfg.peers
                 .iter()
-                .map(|(id, peer)| (*id, peer.hbbft_pk.clone()))
+                .map(|(id, peer)| (*id, peer.hbbft_pk))
                 .collect(),
         );
 

--- a/minimint/src/net/api.rs
+++ b/minimint/src/net/api.rs
@@ -54,7 +54,7 @@ async fn fetch_outcome(req: Request<State>) -> tide::Result {
         .state()
         .fedimint
         .transaction_status(tx_hash)
-        .ok_or(tide::Error::from_str(404, "Not found"))?;
+        .ok_or_else(|| tide::Error::from_str(404, "Not found"))?;
 
     debug!("Sending outcome of transaction {}", tx_hash);
     let body = Body::from_json(&tx_status).expect("encoding error");

--- a/minimint/src/net/connect.rs
+++ b/minimint/src/net/connect.rs
@@ -147,7 +147,7 @@ where
         select_all(
             self.connections
                 .iter_mut()
-                .map(|(id, peer)| Self::receive_from_peer(id.clone(), peer).boxed()),
+                .map(|(id, peer)| Self::receive_from_peer(*id, peer).boxed()),
         )
         .map(|(msg, _, _)| msg)
         .await

--- a/mint-client/src/lib.rs
+++ b/mint-client/src/lib.rs
@@ -674,7 +674,7 @@ impl DatabaseKeyPrefix for PegInKey {
 
 impl DatabaseKey for PegInKey {
     fn from_bytes(data: &[u8]) -> Result<Self, DecodingError> {
-        if data.len() < 1 {
+        if data.is_empty() {
             Err(DecodingError::wrong_length(1, data.len()))
         } else if data[0] != DB_PREFIX_PEG_IN {
             Err(DecodingError::wrong_prefix(DB_PREFIX_PEG_IN, data[0]))

--- a/mint-client/src/lib.rs
+++ b/mint-client/src/lib.rs
@@ -173,7 +173,7 @@ impl MintClient {
             output_idx as u32,
             public_tweak_key,
         )
-        .map_err(|e| ClientError::PegInProofError(e))?;
+        .map_err(ClientError::PegInProofError)?;
 
         peg_in_proof
             .verify(&self.secp, &self.cfg.wallet.peg_in_descriptor)

--- a/modules/minimint-mint/src/config.rs
+++ b/modules/minimint-mint/src/config.rs
@@ -42,16 +42,14 @@ impl GenerateConfig for MintConfig {
                 let config = MintConfig {
                     tbs_sks: params
                         .iter()
-                        .map(|amount| (*amount, tbs_keys[amount].2[peer.to_usize()].clone()))
+                        .map(|amount| (*amount, tbs_keys[amount].2[peer.to_usize()]))
                         .collect(),
                     peer_tbs_pks: peers
                         .iter()
                         .map(|&key_peer| {
                             let keys = params
                                 .iter()
-                                .map(|amount| {
-                                    (*amount, tbs_keys[amount].1[key_peer.to_usize()].clone())
-                                })
+                                .map(|amount| (*amount, tbs_keys[amount].1[key_peer.to_usize()]))
                                 .collect();
                             (key_peer, keys)
                         })

--- a/modules/minimint-mint/src/lib.rs
+++ b/modules/minimint-mint/src/lib.rs
@@ -455,20 +455,18 @@ impl Mint {
         output_id: OutPoint,
         partial_sig: PartialSigResponse,
     ) {
-        match self
+        if self
             .db
             .get_value::<_, SigResponse>(&OutputOutcomeKey(output_id))
             .expect("DB error")
+            .is_some()
         {
-            Some(_) => {
-                debug!(
-                    "Received sig share for finalized issuance {}, ignoring",
-                    output_id
-                );
-                return;
-            }
-            None => {}
-        };
+            debug!(
+                "Received sig share for finalized issuance {}, ignoring",
+                output_id
+            );
+            return;
+        }
 
         debug!(
             "Received sig share from peer {} for issuance {}",

--- a/modules/minimint-wallet/src/config.rs
+++ b/modules/minimint-wallet/src/config.rs
@@ -77,7 +77,7 @@ impl GenerateConfig for WalletConfig {
             .collect();
 
         let client_cfg = WalletClientConfig {
-            peg_in_descriptor: peg_in_descriptor,
+            peg_in_descriptor,
             network: Network::Regtest,
         };
 

--- a/modules/minimint-wallet/src/lib.rs
+++ b/modules/minimint-wallet/src/lib.rs
@@ -594,7 +594,7 @@ impl Wallet {
     ) -> u32 {
         assert!(!proposals.is_empty());
 
-        proposals.sort();
+        proposals.sort_unstable();
         let median_proposal = proposals[proposals.len() / 2];
 
         let consensus_height = self.consensus_height().unwrap_or(0);

--- a/modules/minimint-wallet/src/lib.rs
+++ b/modules/minimint-wallet/src/lib.rs
@@ -59,7 +59,7 @@ pub struct RoundConsensusItem {
     randomness: [u8; 32],
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PegOutSignatureItem {
     txid: Txid,
     signature: Vec<secp256k1::Signature>,
@@ -1036,6 +1036,14 @@ impl std::hash::Hash for PegOutSignatureItem {
         }
     }
 }
+
+impl PartialEq for PegOutSignatureItem {
+    fn eq(&self, other: &PegOutSignatureItem) -> bool {
+        self.txid == other.txid && self.signature == other.signature
+    }
+}
+
+impl Eq for PegOutSignatureItem {}
 
 #[derive(Debug, Error)]
 pub enum WalletError {

--- a/modules/minimint-wallet/src/lib.rs
+++ b/modules/minimint-wallet/src/lib.rs
@@ -200,9 +200,7 @@ impl FederationModule for Wallet {
 
         // Apply signatures to peg-out tx
         for (peer, sig) in peg_out_signatures {
-            if let Err(e) =
-                self.process_peg_out_signature(batch.subtransaction(), peer.into(), &sig)
-            {
+            if let Err(e) = self.process_peg_out_signature(batch.subtransaction(), peer, &sig) {
                 warn!("Error processing peer {}'s peg-out signature: {}", peer, e)
             };
         }

--- a/modules/minimint-wallet/src/lib.rs
+++ b/modules/minimint-wallet/src/lib.rs
@@ -587,9 +587,9 @@ impl Wallet {
 
     /// # Panics
     /// * If proposals is empty
-    async fn process_block_height_proposals<'a>(
+    async fn process_block_height_proposals(
         &self,
-        batch: BatchTx<'a>,
+        batch: BatchTx<'_>,
         mut proposals: Vec<u32>,
     ) -> u32 {
         assert!(!proposals.is_empty());
@@ -623,7 +623,7 @@ impl Wallet {
         self.current_round_consensus().map(|rc| rc.block_height)
     }
 
-    async fn sync_up_to_consensus_heigh<'a>(&self, mut batch: BatchTx<'a>, new_height: u32) {
+    async fn sync_up_to_consensus_heigh(&self, mut batch: BatchTx<'_>, new_height: u32) {
         let old_height = self.consensus_height().unwrap_or(0);
         if new_height < old_height {
             info!(


### PR DESCRIPTION
Solving some Clippy lints. The most impactful one pertains to deriving `PartialEq` while manually implementing `Hash`. This is an error in Clippy, since you could have weird inconsistencies. I've done some manual implementations of `PartialEq`, but I need those to be double-checked.

Otherwise, I've tried to segment the different categories of lints into separate commits, so we can splice out any we don't like, and review should be easier.