### PR TITLE
minimint-api: make `PrefixIter` `Send`

### DIFF
--- a/minimint-api/src/db/mod.rs
+++ b/minimint-api/src/db/mod.rs
@@ -32,7 +32,7 @@ pub trait DatabaseValue: Sized + SerializableDatabaseValue {
     fn from_bytes(data: &[u8]) -> Result<Self, DecodingError>;
 }
 
-pub type PrefixIter = Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>), DatabaseError>>>;
+pub type PrefixIter = Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>), DatabaseError>> + Send>;
 
 pub trait RawDatabase: Send + Sync {
     fn raw_insert_entry(


### PR DESCRIPTION
This additional trait bound should allow usage of `find_by_prefix` with muti-threaded async executors.