### PR TITLE
Remove Database trait and rename RawDatabase to Database

### DIFF
--- a/minimint-api/src/db/mem_impl.rs
+++ b/minimint-api/src/db/mem_impl.rs
@@ -1,5 +1,5 @@
 use super::batch::{BatchItem, DbBatch};
-use super::{DatabaseError, RawDatabase};
+use super::{Database, DatabaseError};
 use crate::db::PrefixIter;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
@@ -26,7 +26,7 @@ impl MemDatabase {
     }
 }
 
-impl RawDatabase for MemDatabase {
+impl Database for MemDatabase {
     fn raw_insert_entry(
         &self,
         key: &[u8],

--- a/minimint-api/src/db/sled_impl.rs
+++ b/minimint-api/src/db/sled_impl.rs
@@ -1,11 +1,11 @@
 use super::batch::{BatchItem, DbBatch};
-use super::{DatabaseError, DecodingError, RawDatabase};
+use super::{Database, DatabaseError, DecodingError};
 use crate::db::PrefixIter;
 use sled::transaction::TransactionError;
 use tracing::{error, trace};
 
 // TODO: maybe make the concrete impl its own crate
-impl RawDatabase for sled::Tree {
+impl Database for sled::Tree {
     fn raw_insert_entry(
         &self,
         key: &[u8],

--- a/minimint-api/src/module/testing.rs
+++ b/minimint-api/src/module/testing.rs
@@ -1,7 +1,7 @@
 use crate::config::GenerateConfig;
 use crate::db::batch::DbBatch;
 use crate::db::mem_impl::MemDatabase;
-use crate::db::{Database, RawDatabase};
+use crate::db::Database;
 use crate::{Amount, FederationModule, InputMeta, OutPoint, PeerId};
 use std::fmt::Debug;
 use std::future::Future;
@@ -112,7 +112,7 @@ where
                     .expect("Faulty output");
             }
 
-            (db as &mut dyn RawDatabase)
+            (db as &mut dyn Database)
                 .apply_batch(batch)
                 .expect("DB error");
 
@@ -121,7 +121,7 @@ where
                 .end_consensus_epoch(batch.transaction(), &mut rng)
                 .await;
 
-            (db as &mut dyn RawDatabase)
+            (db as &mut dyn Database)
                 .apply_batch(batch)
                 .expect("DB error");
         }
@@ -141,7 +141,7 @@ where
 
     pub fn patch_dbs<U>(&mut self, update: U)
     where
-        U: Fn(&mut dyn RawDatabase),
+        U: Fn(&mut dyn Database),
     {
         for (_, _, db) in &mut self.members {
             update(db);

--- a/minimint/src/consensus/mod.rs
+++ b/minimint/src/consensus/mod.rs
@@ -8,7 +8,7 @@ use crate::rng::RngGenerator;
 use crate::transaction::{Input, Output, Transaction, TransactionError};
 use hbbft::honey_badger::Batch;
 use minimint_api::db::batch::{BatchTx, DbBatch};
-use minimint_api::db::{Database, RawDatabase};
+use minimint_api::db::Database;
 use minimint_api::encoding::{Decodable, Encodable};
 use minimint_api::{FederationModule, OutPoint, PeerId, TransactionId};
 use minimint_derive::UnzipConsensus;
@@ -48,7 +48,7 @@ where
     pub ln: LightningModule,
 
     /// KV Database into which all state is persisted to recover from in case of a crash
-    pub db: Arc<dyn RawDatabase>,
+    pub db: Arc<dyn Database>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]

--- a/minimint/src/lib.rs
+++ b/minimint/src/lib.rs
@@ -12,7 +12,7 @@ use tracing::{debug, info, trace, warn};
 
 use config::ServerConfig;
 use consensus::ConsensusOutcome;
-use minimint_api::db::RawDatabase;
+use minimint_api::db::Database;
 use minimint_api::PeerId;
 use minimint_ln::LightningModule;
 
@@ -54,7 +54,7 @@ pub async fn run_minimint(cfg: ServerConfig) {
 
     let threshold = cfg.peers.len() - cfg.max_faulty();
 
-    let database: Arc<dyn RawDatabase> =
+    let database: Arc<dyn Database> =
         Arc::new(sled::open(&cfg.db_path).unwrap().open_tree("mint").unwrap());
 
     let mint = minimint_mint::Mint::new(cfg.mint.clone(), threshold, database.clone());

--- a/mint-client/src/lib.rs
+++ b/mint-client/src/lib.rs
@@ -12,7 +12,7 @@ use minimint::modules::wallet::txoproof::{PegInProofError, TxOutProof};
 use minimint::transaction as mint_tx;
 use minimint::transaction::{Output, TransactionItem};
 use minimint_api::db::batch::DbBatch;
-use minimint_api::db::{Database, RawDatabase};
+use minimint_api::db::Database;
 use minimint_api::{Amount, TransactionId};
 use minimint_api::{OutPoint, PeerId};
 
@@ -29,7 +29,7 @@ pub mod wallet;
 
 pub struct MintClient {
     cfg: ClientConfig,
-    db: Arc<dyn RawDatabase>,
+    db: Arc<dyn Database>,
     api: Arc<dyn api::FederationApi>,
     secp: Secp256k1<All>,
     wallet: wallet::WalletClient,
@@ -39,7 +39,7 @@ pub struct MintClient {
 }
 
 impl MintClient {
-    pub fn new(cfg: ClientConfig, db: Arc<dyn RawDatabase>, secp: Secp256k1<All>) -> Self {
+    pub fn new(cfg: ClientConfig, db: Arc<dyn Database>, secp: Secp256k1<All>) -> Self {
         let api = api::HttpFederationApi::new(
             cfg.api_endpoints
                 .iter()
@@ -56,7 +56,7 @@ impl MintClient {
 
     pub fn new_with_api(
         cfg: ClientConfig,
-        db: Arc<dyn RawDatabase>,
+        db: Arc<dyn Database>,
         api: Arc<dyn FederationApi>,
         secp: Secp256k1<All>,
     ) -> MintClient {

--- a/mint-client/src/ln/mod.rs
+++ b/mint-client/src/ln/mod.rs
@@ -17,14 +17,14 @@ use minimint::modules::ln::{
     ContractAccount, ContractInput, ContractOrOfferOutput, ContractOutput,
 };
 use minimint_api::db::batch::BatchTx;
-use minimint_api::db::{Database, RawDatabase};
+use minimint_api::db::Database;
 use minimint_api::Amount;
 use rand::{CryptoRng, RngCore};
 use std::sync::Arc;
 use thiserror::Error;
 
 pub struct LnClient {
-    pub db: Arc<dyn RawDatabase>,
+    pub db: Arc<dyn Database>,
     pub cfg: ln::config::LightningModuleClientConfig,
     pub api: Arc<dyn FederationApi>,
     pub secp: secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
@@ -155,7 +155,7 @@ mod tests {
     use minimint::transaction::Transaction;
     use minimint_api::db::batch::DbBatch;
     use minimint_api::db::mem_impl::MemDatabase;
-    use minimint_api::db::{Database, RawDatabase};
+    use minimint_api::db::Database;
     use minimint_api::module::testing::FakeFed;
     use minimint_api::{Amount, OutPoint, TransactionId};
     use std::ops::DerefMut;
@@ -203,8 +203,7 @@ mod tests {
         }
     }
 
-    async fn new_mint_and_client() -> (Arc<tokio::sync::Mutex<Fed>>, LnClient, Arc<dyn RawDatabase>)
-    {
+    async fn new_mint_and_client() -> (Arc<tokio::sync::Mutex<Fed>>, LnClient, Arc<dyn Database>) {
         let fed = Arc::new(tokio::sync::Mutex::new(
             FakeFed::<LightningModule, LightningModuleClientConfig>::new(
                 4,
@@ -216,7 +215,7 @@ mod tests {
         ));
         let api = FakeApi { mint: fed.clone() };
 
-        let client_db: Arc<dyn RawDatabase> = Arc::new(MemDatabase::new());
+        let client_db: Arc<dyn Database> = Arc::new(MemDatabase::new());
         let client = LnClient {
             db: client_db.clone(),
             cfg: fed.lock().await.client_cfg().clone(),

--- a/mint-client/src/mint/mod.rs
+++ b/mint-client/src/mint/mod.rs
@@ -9,7 +9,7 @@ use minimint::modules::mint::{
     BlindToken, Coin, CoinNonce, InvalidAmountTierError, Keys, SigResponse, SignRequest,
 };
 use minimint_api::db::batch::{BatchItem, BatchTx};
-use minimint_api::db::{Database, RawDatabase};
+use minimint_api::db::Database;
 use minimint_api::encoding::{Decodable, Encodable};
 use minimint_api::{Amount, OutPoint, TransactionId};
 use rand::{CryptoRng, Rng, RngCore};
@@ -25,7 +25,7 @@ use tracing::{debug, trace};
 /// Federation module client for the Mint module. It can both create transaction inputs and outputs
 /// of the mint type.
 pub struct MintClient {
-    pub db: Arc<dyn RawDatabase>,
+    pub db: Arc<dyn Database>,
     pub cfg: mint::config::MintClientConfig,
     pub api: Arc<dyn FederationApi>,
     pub secp: secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
@@ -417,7 +417,7 @@ mod tests {
     use minimint::transaction::Transaction;
     use minimint_api::db::batch::DbBatch;
     use minimint_api::db::mem_impl::MemDatabase;
-    use minimint_api::db::{Database, RawDatabase};
+    use minimint_api::db::Database;
     use minimint_api::module::testing::FakeFed;
     use minimint_api::{Amount, OutPoint, TransactionId};
     use std::sync::Arc;
@@ -459,11 +459,8 @@ mod tests {
         }
     }
 
-    async fn new_mint_and_client() -> (
-        Arc<tokio::sync::Mutex<Fed>>,
-        MintClient,
-        Arc<dyn RawDatabase>,
-    ) {
+    async fn new_mint_and_client() -> (Arc<tokio::sync::Mutex<Fed>>, MintClient, Arc<dyn Database>)
+    {
         let fed = Arc::new(tokio::sync::Mutex::new(
             FakeFed::<Mint, MintClientConfig>::new(
                 4,
@@ -475,7 +472,7 @@ mod tests {
         ));
         let api = FakeApi { mint: fed.clone() };
 
-        let client_db: Arc<dyn RawDatabase> = Arc::new(MemDatabase::new());
+        let client_db: Arc<dyn Database> = Arc::new(MemDatabase::new());
         let client = MintClient {
             db: client_db.clone(),
             cfg: fed.lock().await.client_cfg().clone(),
@@ -489,7 +486,7 @@ mod tests {
     async fn issue_tokens<'a, R: rand::RngCore + rand::CryptoRng>(
         fed: &'a tokio::sync::Mutex<Fed>,
         client: &'a MintClient,
-        client_db: Arc<dyn RawDatabase>,
+        client_db: Arc<dyn Database>,
         amt: Amount,
         rng: &'a mut R,
     ) {

--- a/mint-client/src/wallet/mod.rs
+++ b/mint-client/src/wallet/mod.rs
@@ -8,7 +8,7 @@ use minimint::modules::wallet::tweakable::Tweakable;
 use minimint::modules::wallet::txoproof::{PegInProof, TxOutProof};
 use minimint::modules::wallet::PegOut;
 use minimint_api::db::batch::BatchTx;
-use minimint_api::db::{Database, RawDatabase};
+use minimint_api::db::Database;
 use minimint_api::Amount;
 use miniscript::DescriptorTrait;
 use rand::{CryptoRng, RngCore};
@@ -22,7 +22,7 @@ mod db;
 /// Federation module client for the Wallet module. It can both create transaction inputs and
 /// outputs of the wallet (on-chain) type.
 pub struct WalletClient {
-    pub db: Arc<dyn RawDatabase>,
+    pub db: Arc<dyn Database>,
     pub cfg: wallet::config::WalletClientConfig,
     pub api: Arc<dyn FederationApi>,
     pub secp: secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
@@ -150,7 +150,7 @@ mod tests {
     use minimint::outcome::{OutputOutcome, TransactionStatus};
     use minimint::transaction::Transaction;
     use minimint_api::db::mem_impl::MemDatabase;
-    use minimint_api::db::{Database, RawDatabase};
+    use minimint_api::db::Database;
     use minimint_api::module::testing::FakeFed;
     use minimint_api::{Amount, OutPoint, TransactionId};
     use miniscript::DescriptorTrait;
@@ -193,7 +193,7 @@ mod tests {
     async fn new_mint_and_client() -> (
         Arc<tokio::sync::Mutex<Fed>>,
         WalletClient,
-        Arc<dyn RawDatabase>,
+        Arc<dyn Database>,
         FakeBitcoindRpcController,
     ) {
         let btc_rpc = FakeBitcoindRpc::new();
@@ -220,7 +220,7 @@ mod tests {
 
         let api = FakeApi { _mint: fed.clone() };
 
-        let client_db: Arc<dyn RawDatabase> = Arc::new(MemDatabase::new());
+        let client_db: Arc<dyn Database> = Arc::new(MemDatabase::new());
         let client = WalletClient {
             db: client_db.clone(),
             cfg: fed.lock().await.client_cfg().clone(),

--- a/modules/minimint-ln/src/lib.rs
+++ b/modules/minimint-ln/src/lib.rs
@@ -27,7 +27,7 @@ use async_trait::async_trait;
 use bitcoin_hashes::Hash as BitcoinHash;
 use itertools::Itertools;
 use minimint_api::db::batch::{BatchItem, BatchTx};
-use minimint_api::db::{Database, RawDatabase};
+use minimint_api::db::Database;
 use minimint_api::encoding::{Decodable, Encodable};
 use minimint_api::{Amount, FederationModule, PeerId};
 use minimint_api::{InputMeta, OutPoint};
@@ -58,7 +58,7 @@ use tracing::{debug, error, trace, warn};
 /// [Incoming]: contracts::incoming::IncomingContract
 pub struct LightningModule {
     cfg: LightningModuleConfig,
-    db: Arc<dyn RawDatabase>,
+    db: Arc<dyn Database>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
@@ -477,7 +477,7 @@ impl FederationModule for LightningModule {
 }
 
 impl LightningModule {
-    pub fn new(cfg: LightningModuleConfig, db: Arc<dyn RawDatabase>) -> LightningModule {
+    pub fn new(cfg: LightningModuleConfig, db: Arc<dyn Database>) -> LightningModule {
         LightningModule { cfg, db }
     }
 

--- a/modules/minimint-ln/tests/ln_contracts.rs
+++ b/modules/minimint-ln/tests/ln_contracts.rs
@@ -1,5 +1,5 @@
 use bitcoin_hashes::Hash as BitcoinHash;
-use minimint_api::db::{Database, RawDatabase};
+use minimint_api::db::Database;
 use minimint_api::module::testing::FakeFed;
 use minimint_api::{Amount, OutPoint};
 use minimint_ln::config::LightningModuleClientConfig;
@@ -223,7 +223,7 @@ async fn test_incoming() {
 }
 
 /// Hack to set consensus height of wallet module which is being used by the LN module too for now.
-fn set_block_height(db: &mut dyn RawDatabase, block_height: u32) {
+fn set_block_height(db: &mut dyn Database, block_height: u32) {
     use minimint_api::encoding::{Decodable, Encodable};
 
     const DB_PREFIX_ROUND_CONSENSUS: u8 = 0x32;

--- a/modules/minimint-mint/src/lib.rs
+++ b/modules/minimint-mint/src/lib.rs
@@ -7,7 +7,7 @@ use crate::db::{
 use async_trait::async_trait;
 use itertools::Itertools;
 use minimint_api::db::batch::{BatchItem, BatchTx, DbBatch};
-use minimint_api::db::{Database, RawDatabase};
+use minimint_api::db::Database;
 use minimint_api::encoding::{Decodable, Encodable};
 use minimint_api::{Amount, FederationModule, InputMeta, OutPoint, PeerId};
 use rand::{CryptoRng, RngCore};
@@ -39,7 +39,7 @@ pub struct Mint {
     pub_key_shares: BTreeMap<PeerId, Keys<PublicKeyShare>>,
     pub_key: HashMap<Amount, AggregatePublicKey>,
     threshold: usize, // TODO: move to cfg
-    db: Arc<dyn RawDatabase>,
+    db: Arc<dyn Database>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -311,7 +311,7 @@ impl Mint {
     /// * If there are no amount tiers
     /// * If the amount tiers for secret and public keys are inconsistent
     /// * If the pub key belonging to the secret key share is not in the pub key list.
-    pub fn new(cfg: MintConfig, threshold: usize, db: Arc<dyn RawDatabase>) -> Mint {
+    pub fn new(cfg: MintConfig, threshold: usize, db: Arc<dyn Database>) -> Mint {
         assert!(cfg.tbs_sks.tiers().count() > 0);
 
         // The amount tiers are implicitly provided by the key sets, make sure they are internally

--- a/modules/minimint-wallet/src/lib.rs
+++ b/modules/minimint-wallet/src/lib.rs
@@ -23,7 +23,7 @@ use bitcoin::{
 use bitcoincore_rpc::Auth;
 use itertools::Itertools;
 use minimint_api::db::batch::{BatchItem, BatchTx};
-use minimint_api::db::{Database, RawDatabase};
+use minimint_api::db::Database;
 use minimint_api::encoding::{Decodable, Encodable};
 use minimint_api::{FederationModule, InputMeta, OutPoint, PeerId};
 use minimint_derive::UnzipConsensus;
@@ -83,7 +83,7 @@ pub struct Wallet {
     cfg: WalletConfig,
     secp: Secp256k1<All>,
     btc_rpc: Box<dyn BitcoindRpc>,
-    db: Arc<dyn RawDatabase>,
+    db: Arc<dyn Database>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Encodable, Decodable)]
@@ -407,7 +407,7 @@ impl FederationModule for Wallet {
 }
 
 impl Wallet {
-    pub async fn new(cfg: WalletConfig, db: Arc<dyn RawDatabase>) -> Result<Wallet, WalletError> {
+    pub async fn new(cfg: WalletConfig, db: Arc<dyn Database>) -> Result<Wallet, WalletError> {
         let gen_cfg = cfg.clone();
         let bitcoind_rpc_gen = move || -> Box<dyn BitcoindRpc> {
             Box::new(
@@ -425,7 +425,7 @@ impl Wallet {
     // TODO: work around bitcoind_gen being a closure, maybe make clonable?
     pub async fn new_with_bitcoind(
         cfg: WalletConfig,
-        db: Arc<dyn RawDatabase>,
+        db: Arc<dyn Database>,
         bitcoind_gen: impl Fn() -> Box<dyn BitcoindRpc>,
     ) -> Result<Wallet, WalletError> {
         let broadcaster_bitcoind_rpc = bitcoind_gen();
@@ -992,7 +992,7 @@ pub fn is_address_valid_for_network(address: &Address, network: Network) -> bool
     }
 }
 
-async fn broadcast_pending_tx(db: Arc<dyn RawDatabase>, rpc: Box<dyn BitcoindRpc>) {
+async fn broadcast_pending_tx(db: Arc<dyn Database>, rpc: Box<dyn BitcoindRpc>) {
     loop {
         let pending_tx = db
             .find_by_prefix::<_, PendingTransactionKey, PendingTransaction>(


### PR DESCRIPTION
Extension trait is not needed. We can just use inherent impl for `dyn Database`.

important changes are in `minimint-api/src/db/mod.rs`, rest are just side effects.