### PR TITLE
Fixed typo and missing scope for docs

### DIFF
--- a/minimint/src/transaction.rs
+++ b/minimint/src/transaction.rs
@@ -116,7 +116,7 @@ impl Transaction {
     }
 
     /// Hash the transaction excluding the signature. This hash is what the signature inside the
-    /// transaction commits to. To generate it without already having a signature use [Transaction::tx_hash_from_parts()].
+    /// transaction commits to. To generate it without already having a signature use [`Self::tx_hash_from_parts`].
     pub fn tx_hash(&self) -> TransactionId {
         Self::tx_hash_from_parts(&self.inputs, &self.outputs)
     }

--- a/minimint/src/transaction.rs
+++ b/minimint/src/transaction.rs
@@ -116,7 +116,7 @@ impl Transaction {
     }
 
     /// Hash the transaction excluding the signature. This hash is what the signature inside the
-    /// transaction commits to. To generate it without already having a signature use [tx_hash_from_parts].
+    /// transaction commits to. To generate it without already having a signature use [Transaction::tx_hash_from_parts()].
     pub fn tx_hash(&self) -> TransactionId {
         Self::tx_hash_from_parts(&self.inputs, &self.outputs)
     }

--- a/modules/minimint-ln/src/contracts/incoming.rs
+++ b/modules/minimint-ln/src/contracts/incoming.rs
@@ -53,7 +53,7 @@ pub struct IncomingContract {
     pub gateway_key: secp256k1::schnorrsig::PublicKey,
 }
 
-/// The funded version of an [`IncomingCotnract`] contains the [`OutPoint`] of it's creation. Since
+/// The funded version of an [`IncomingContract`] contains the [`OutPoint`] of it's creation. Since
 /// this kind of contract can only be funded once this out point is unambiguous. The out point is
 /// used to update the output outcome once decryption finishes.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Encodable, Decodable, Serialize, Deserialize)]


### PR DESCRIPTION
I am not sure  whether Self::(...) is better than Transaction::(...)
 https://doc.rust-lang.org/rustdoc/linking-to-items-by-name.html