### PR TITLE
minimint-api: implement proper `bitcoin::Address` encoding

### DIFF
--- a/minimint-api/src/encoding/btc.rs
+++ b/minimint-api/src/encoding/btc.rs
@@ -45,20 +45,23 @@ impl Decodable for bitcoin::Amount {
     }
 }
 
-// FIXME: find a proper binary encoding that still includes the network
 impl Encodable for bitcoin::Address {
-    fn consensus_encode<W: std::io::Write>(&self, writer: W) -> Result<usize, Error> {
-        self.to_string().as_bytes().consensus_encode(writer)
+    fn consensus_encode<W: std::io::Write>(&self, mut writer: W) -> Result<usize, Error> {
+        let mut len = 0;
+        len += self.network.magic().consensus_encode(&mut writer)?;
+        len += self.script_pubkey().consensus_encode(writer)?;
+        Ok(len)
     }
 }
 
 impl Decodable for bitcoin::Address {
-    fn consensus_decode<D: std::io::Read>(d: D) -> Result<Self, DecodeError> {
-        let bytes = Vec::<u8>::consensus_decode(d)?;
-        String::from_utf8(bytes)
-            .map_err(DecodeError::from_err)?
-            .parse()
-            .map_err(DecodeError::from_err)
+    fn consensus_decode<D: std::io::Read>(mut d: D) -> Result<Self, DecodeError> {
+        let network = bitcoin::Network::from_magic(u32::consensus_decode(&mut d)?)
+            .ok_or_else(|| DecodeError::from_str("Unknown network"))?;
+        let script_pk = bitcoin::Script::consensus_decode(&mut d)?;
+
+        bitcoin::Address::from_script(&script_pk, network)
+            .ok_or_else(|| DecodeError::from_str("Unknown script type"))
     }
 }
 
@@ -81,6 +84,7 @@ mod tests {
     use crate::encoding::{Decodable, Encodable};
     use bitcoin::hashes::Hash as BitcoinHash;
     use std::io::Cursor;
+    use std::str::FromStr;
 
     #[test]
     fn sha256_roundtrip() {
@@ -90,5 +94,31 @@ mod tests {
         let hash_decoded =
             bitcoin::hashes::sha256::Hash::consensus_decode(Cursor::new(encoded)).unwrap();
         assert_eq!(hash, hash_decoded);
+    }
+
+    #[test]
+    fn address_roundtrip() {
+        let addresses = [
+            "bc1p2wsldez5mud2yam29q22wgfh9439spgduvct83k3pm50fcxa5dps59h4z5",
+            "mxMYaq5yWinZ9AKjCDcBEbiEwPJD9n2uLU",
+            "1FK8o7mUxyd6QWJAUw7J4vW7eRxuyjj6Ne",
+            "3JSrSU7z7R1Yhh26pt1zzRjQz44qjcrXwb",
+            "tb1qunn0thpt8uk3yk2938ypjccn3urxprt78z9ccq",
+            "2MvUMRv2DRHZi3VshkP7RMEU84mVTfR9xjq",
+        ];
+
+        for address_str in addresses {
+            let address =
+                bitcoin::Address::from_str(address_str).expect("All tested addresses are valid");
+            let mut encoding = vec![];
+            address
+                .consensus_encode(&mut encoding)
+                .expect("Encoding to vec can't fail");
+            let cursor = Cursor::new(encoding);
+            let parsed_address =
+                bitcoin::Address::consensus_decode(cursor).expect("Decoding address failed");
+
+            assert_eq!(address, parsed_address);
+        }
     }
 }


### PR DESCRIPTION
Fixes a TODO left when I took a shortcut by encoding the address string.