### PR TITLE
De-parallelize transaction processing

### DIFF
--- a/minimint-api/src/module/mod.rs
+++ b/minimint-api/src/module/mod.rs
@@ -41,7 +41,7 @@ pub struct ApiEndpoint<M> {
 #[async_trait(?Send)]
 pub trait FederationModule: Sized {
     type Error;
-    type TxInput;
+    type TxInput: Send + Sync;
     type TxOutput;
     type TxOutputOutcome;
     type ConsensusItem;
@@ -70,7 +70,7 @@ pub trait FederationModule: Sized {
     /// constructing such lookup tables.
     fn build_verification_cache<'a>(
         &'a self,
-        inputs: impl Iterator<Item = &'a Self::TxInput>,
+        inputs: impl Iterator<Item = &'a Self::TxInput> + Send,
     ) -> Self::VerificationCache;
 
     /// Validate a transaction input before submitting it to the unconfirmed transaction pool. This

--- a/minimint-api/src/module/testing.rs
+++ b/minimint-api/src/module/testing.rs
@@ -91,7 +91,9 @@ where
         &mut self,
         inputs: &[M::TxInput],
         outputs: &[(OutPoint, M::TxOutput)],
-    ) {
+    ) where
+        <M as FederationModule>::TxInput: Send + Sync,
+    {
         let mut rng = rand::rngs::OsRng::new().unwrap();
         let fake_ic = FakeInterconnect::new_block_height_responder(self.block_height.clone());
 

--- a/minimint/src/consensus/mod.rs
+++ b/minimint/src/consensus/mod.rs
@@ -380,7 +380,7 @@ where
 
     fn build_verification_caches<'a>(
         &self,
-        transactions: impl Iterator<Item = &'a Transaction> + Clone,
+        transactions: impl Iterator<Item = &'a Transaction> + Clone + Send,
     ) -> VerificationCaches {
         let mint_input_iter = transactions
             .clone()

--- a/modules/minimint-ln/src/lib.rs
+++ b/modules/minimint-ln/src/lib.rs
@@ -126,6 +126,7 @@ impl FederationModule for LightningModule {
     type TxOutput = ContractOrOfferOutput;
     type TxOutputOutcome = OutputOutcome;
     type ConsensusItem = DecryptionShareCI;
+    type VerificationCache = ();
 
     async fn consensus_proposal<'a>(
         &'a self,
@@ -183,9 +184,16 @@ impl FederationModule for LightningModule {
         batch.commit();
     }
 
+    fn build_verification_cache<'a>(
+        &'a self,
+        _inputs: impl Iterator<Item = &'a Self::TxInput>,
+    ) -> Self::VerificationCache {
+    }
+
     fn validate_input<'a>(
         &self,
         interconnect: &dyn ModuleInterconect,
+        _cache: &Self::VerificationCache,
         input: &'a Self::TxInput,
     ) -> Result<InputMeta<'a>, Self::Error> {
         let account: ContractAccount = self
@@ -247,8 +255,9 @@ impl FederationModule for LightningModule {
         interconnect: &'a dyn ModuleInterconect,
         mut batch: BatchTx<'a>,
         input: &'b Self::TxInput,
+        cache: &Self::VerificationCache,
     ) -> Result<InputMeta<'b>, Self::Error> {
-        let meta = self.validate_input(interconnect, input)?;
+        let meta = self.validate_input(interconnect, cache, input)?;
 
         let account_db_key = ContractKey(input.crontract_id);
         let mut contract_account = self


### PR DESCRIPTION
As mentioned in https://github.com/fedimint/minimint/pull/49#issuecomment-1079118926 a lot of problems arise from parallel processing of transactions. This PR will reduce parallelism in transaction processing and confine it to well-controlled areas of the code where no side effects need to be controlled for. Fixes #28 