### PR TITLE
Fork hbbft to get minimint compiling on M1 Mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,8 +1228,7 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 [[package]]
 name = "hbbft"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1890ac314fff1fa83316de9c327b6d2f80fff4ccb4380b9c69da0d755b495051"
+source = "git+https://github.com/fedimint/hbbft?branch=minimint#aeb5d5a5ebec63428bbb509f98b41e1eeec68221"
 dependencies = [
  "bincode",
  "byteorder",
@@ -1533,6 +1532,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
+name = "libm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+
+[[package]]
 name = "lightning"
 version = "0.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,12 +1625,6 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -1962,7 +1961,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.7.0",
+ "smallvec",
  "winapi",
 ]
 
@@ -2398,14 +2397,14 @@ dependencies = [
 
 [[package]]
 name = "reed-solomon-erasure"
-version = "3.1.1"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77cbbd4c02f53e345fe49e74255a1b10080731ffb2a03475e11df7fc8a043c37"
+checksum = "7170bac0d8306941e101df0caaa6518b10bc4232dd36c34f1cb78b8a063024db"
 dependencies = [
- "cc",
- "libc",
- "rayon",
- "smallvec 0.6.14",
+ "libm",
+ "parking_lot",
+ "smallvec",
+ "spin",
 ]
 
 [[package]]
@@ -2708,15 +2707,6 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
@@ -2730,6 +2720,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 
 [[package]]
 name = "stable_deref_trait"
@@ -3191,7 +3187,7 @@ dependencies = [
  "matchers",
  "regex",
  "sharded-slab",
- "smallvec 1.7.0",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",

--- a/minimint/Cargo.toml
+++ b/minimint/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1.42"
 bincode = "1.3.1"
 bitcoin = "0.27.0"
 futures = "0.3.9"
-hbbft = "0.1.1"
+hbbft = { git = "https://github.com/fedimint/hbbft", branch = "minimint" }
 hex = "0.4.2"
 itertools = "0.10.0"
 minimint-api = { path = "../minimint-api" }


### PR DESCRIPTION
Before this commit I ran into [this issue](https://github.com/rust-rse/reed-solomon-erasure/issues/86) on M1 Mac. 

After this commit, the project compiles and the pass on M1 Mac. Needed to fork [hbbft](https://github.com/poanetwork/hbbft) in order to upgrade [reed-solomon-erasure](https://github.com/rust-rse/reed-solomon-erasure) to 5.0.1 in order to include [this commit](https://github.com/rust-rse/reed-solomon-erasure/pull/89).

I have not idea if I correctly upgraded the [reed-solomon-erasure](https://github.com/rust-rse/reed-solomon-erasure) dependency in hbbfd. [Here's the commit](https://github.com/justinmoon/hbbft/commit/8cf186bcb9b30137fc7d0e1c5d52cfe9202ca206) where I did it. I just hacked it to get it compiling. No tests fail, but the `reordering_attack` test doesn't finish. And a suspicious `tests/binary_agreement_mitm.proptest-regressions` file is saved with the following contents:

```
# Seeds for failure cases proptest has generated in the past. It is
# automatically read and these particular cases re-run before any
# novel cases are generated.
#
# It is recommended to check this file in to source control so that
# everyone who runs the test benefits from these saved cases.
xs 1514293346 484839646 4229023239 3780667848 # shrinks to seed = [217, 197, 151, 151, 13, 244, 31, 82, 44, 31, 141, 203, 43, 206, 53, 58]
```

Before merging we should move the hbbft fork from my personal GitHub account to fedimint org.