### PR TITLE
Optimizing Build times

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,5 +71,3 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Integration Tests with nix-shell
         run: nix-shell --command ./scripts/integrationtest.sh
-      - name: Running nix-build
-        run: nix-build default.nix

--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,7 @@ in naersk.buildPackage {
     url = "https://github.com/fedimint/minimint";
     ref = "master";
   };
+  copyTarget = true; # copy the target directory to the build dir
   gitAllRefs = true;
   gitSubmodules = true;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,4 @@
-{ pkgs ? import <nixpkgs> {
-    overlays = [
-(import "${(fetchTarball "https://github.com/nix-community/fenix/archive/main.tar.gz")}/overlay.nix")
-      (self: super: {
-          rustc = super.fenix.latest.rustc;
-          cargo  = super.fenix.latest.cargo;
-          rust-src = super.fenix.latest.rust-src;
-      }
-        )
-    ];
-  }
-}:
+{ pkgs ? import <nixpkgs> {}}:
 
 pkgs.mkShell {
   packages = with pkgs; [
@@ -20,7 +9,9 @@ pkgs.mkShell {
     clightning
     jq
   ];
+buildInputs = [
+   (import ./default.nix )
+   ];
 
-  RUST_SRC_PATH = "${pkgs.rust-src}/lib/rustlib/src/rust/library";
 }
 


### PR DESCRIPTION
1. Masked fenix overlay and we will be adding packages manually whenever needed.
2. Building nix-expressions from nix-shell itself, so integrationtests script can use binaries and avoid compiling twice.
3. Removed SRC_DIR and BIN_DIR from integrationtest script as we will be using binaries generated by nix expressions.
Fix #67 