### PR TITLE
Fix CI after adding openssl dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,4 +11,9 @@ in naersk.buildPackage {
   };
   gitAllRefs = true;
   gitSubmodules = true;
+  buildInputs = [
+      pkgs.openssl
+      pkgs.pkg-config
+      pkgs.perl
+  ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,9 @@
 
 pkgs.mkShell {
   packages = with pkgs; [
+    openssl
+    pkg-config
+    perl
     rustc
     cargo
     rust-analyzer
@@ -22,5 +25,7 @@ pkgs.mkShell {
   ];
 
   RUST_SRC_PATH = "${pkgs.rust-src}/lib/rustlib/src/rust/library";
+  OPENSSL_DIR = "${pkgs.openssl.dev}";
+  OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
 }
 


### PR DESCRIPTION
Apparently #68 added OpenSSL as a dependency but we changed our new nix-based CI doesn't include it and apparently wasn't run again for #68 after #45 was merged.