### PR TITLE
Fix peg-out client CLI command

### DIFF
--- a/scripts/integrationtest.sh
+++ b/scripts/integrationtest.sh
@@ -117,7 +117,7 @@ $MINT_CLIENT fetch
 
 # peg out
 PEG_OUT_ADDR="$($BTC_CLIENT getnewaddress)"
-$MINT_CLIENT peg-out $PEG_OUT_ADDR "500 sat"
+$MINT_CLIENT peg-out $PEG_OUT_ADDR 500
 sleep 5 # wait for tx to be included
 mine_blocks 120
 await_block_sync


### PR DESCRIPTION
Currently the `peg-out` command is broken. It uses `bitcoin::Amount::from_str` to parse the amount argument which assumes a string of the form "\<amount\> \<denomination\>". Obviously, this doesn't work for a CLI where spaces imply separate arguments. Instead, use sats.