### PR TITLE
Stop startfed.sh with ctrl-c instead of enter

### DIFF
--- a/scripts/startfed.sh
+++ b/scripts/startfed.sh
@@ -14,6 +14,6 @@ for ((ID=$2; ID<SIZE; ID++)); do
   (target/release/server cfg/server-$ID.json 2>&1 | sed -e "s/^/mint $ID: /" ) &
 done
 
-read -p "Press enter to stop processes"
+wait
 
 kill 0


### PR DESCRIPTION
Normally hitting "enter" in the logs helps to:
1. Scroll back to bottom of the log after scrolling back in history
2. Put some spaces in output to help separate things visually

So I often find myself hitting "enter" out of habit in the `startfed.sh` logs and accidentally killing it!

This "works on my machine" ...