### PR TITLE
Pass node pubkey as parameter to gw_configgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **This is an experimental implementation of a federated Chaumian bank. DO NOT USE IT WITH REAL MONEY, THERE ARE MULTIPLE KNOWN SECURITY ISSUES.**
 
 ## Getting involved
+
 If you want to learn more about the general idea go to [fedimint.org](https://fedimint.org/), beyond a high level explanation you can also find links to talks and blog posts at the bottom of the page.
 
 There exist three main communication channels for the project at the moment:
@@ -15,6 +16,7 @@ PRs fixing TODOs or issues are always welcome, it might be a good idea though to
 To get started with the code base have a look at the next section. Happy hacking!
 
 ## Running MiniMint locally
+
 MiniMint is tested and developed using rust `stable`, you can get it through your package manager or from [rustup.rs](https://rustup.rs/).
 
 MiniMint consists of three kinds of services:
@@ -24,7 +26,20 @@ MiniMint consists of three kinds of services:
 
 In the following we will set up all three.
 
+### Running bitcoind and lightningd
+
+To test out MiniMint you'll need to run `bitcoind` and (optionally) 2 instances `lightningd` to send and receive via Lightning:
+
+```shell
+bitcoind -regtest -fallbackfee=0.0004 -txindex -server -rpcuser=bitcoin -rpcpassword=bitcoin
+
+# optional
+lightningd --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=ln1 --addr=127.0.0.1:9000
+lightningd --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=ln2 --addr=127.0.0.1:9001
+```
+
 ### Generating config
+
 You first need to generate some config. All scripts assume config to be located in a folder called `cfg`. Then you can generate the necessary configuration files as follows:
 
 ```shell
@@ -46,30 +61,29 @@ cargo run --bin configgen cfg 4 5000 6000 1 10 100 1000 10000 100000 1000000 100
 This will both create all the `server-n.json` config files and one `federation_client.json`. The server configs are already complete and can be used to run the nodes. The client config on the other hand needs to be amended with some information about a lightning gateway it can use. For that we run
 
 ```shell
-cargo run --bin gw_configgen -- cfg <ln_rpc>
+cargo run --bin gw_configgen -- cfg <ln-rpc-path> <ln-node-pub-key>
 ```
 
-The **`<ln_rpc>`** placeholder should be replaced with the absolute path to a c-lightning `lightning-rpc` socket, typically located at `/home/<user>/.lightning/regtest/lightning-rpc` for regtest nodes. If you do not intend to use the LN feature this path does not have to be correct and you will not even have to start the gateway. **But for the client to start we need to add at least a dummy gateway**.
+The **`<ln-rpc>`** placeholder should be replaced with the absolute path to a c-lightning `lightning-rpc` socket, typically located at `/home/<user>/.lightning/regtest/lightning-rpc` for regtest nodes. If you do not intend to use the LN feature this path does not have to be correct and you will not even have to start the gateway. **But for the client to start we need to add at least a dummy gateway**.
 
-An example with concrete parameters could look as follows:
-```shell
-cargo run --bin gw_configgen -- cfg /home/user/.lightning/regtest/lightning-rpc
-```
+The **`<ln-node-pub-key>`** placeholder should be replaced with the gateway's lightning node pubkey. Once again, you can pass a fake pubkey if you don't want to use lightning (e.g. `030160715ddbe8d4cd68e00fc910d6dac161fcfa457bfef4fd8bb93350cc2966aa`).
 
-`gw_configgen` will both generate the final `client.json` for clients as well as `gateway.json` which will be used by the Lightning gateway. If you have c-lighning installed you can already create two directories for the lightning nodes to use the gateway later
+`gw_configgen` will both generate the final `cfg/client.json` for clients as well as `cfg/gateway.json` which will be used by the Lightning gateway.
+
+Run the client config and set `ln1` as the gateway. If you don't want to use MiniMint with Lightning, you can skip the first command and hard-code a fake pubkey in the second command (e.g. `030160715ddbe8d4cd68e00fc910d6dac161fcfa457bfef4fd8bb93350cc2966aa`).
+
 ```shell
-mkdir -p ln1 ln2
-```
-Run the client config and set `ln1` as the gateway. If you don't want to use Minimint with Lightning, you can skip the first command and hard-code a fake pubkey (e.g. `030160715ddbe8d4cd68e00fc910d6dac161fcfa457bfef4fd8bb93350cc2966aa`).
-```shell
-$ lightning-cli --network regtest --lightning-dir=ln1 getinfo
+lightning-cli --network regtest --lightning-dir=ln1 getinfo
 {
-    "id": <pubkey>,
+    "id": <ln-node-pub-key>,
     ...
 }
-$ cargo run --bin gw_configgen -- cfg "ln1/regtest/lightning-rpc" <pubkey>
+
+cargo run --bin gw_configgen -- cfg "ln1/regtest/lightning-rpc" <ln-node-pub-key>
 ```
+
 ### Running the mints
+
 A script for running all mints and a regtest `bitcoind` at once is provided at `scripts/startfed.sh`. Run it as follows:
 
 ```shell
@@ -81,39 +95,40 @@ The `0` in the end specifies how many nodes to leave out. E.g. changing it to on
 Log output can be adjusted using the `RUST_LOG` environment variable and is set to `info` by default. Logging can be adjusted per module, see the [`env_logger` documentation](https://docs.rs/env_logger/0.8.4/env_logger/#enabling-logging) for details.
 ###Setting up a channel from LN1 to LN2
 If you want to pay invoices later, the node (ln1) you've set as a gateway needs to have a channel to the payee node :
-```shell
-#start both nodes
-lightningd --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=ln1 --addr=127.0.0.1:9000
-lightningd --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=ln2 --addr=127.0.0.1:9001
-```
-Send your gateway node some funds :
-```shell
-#get an address from ln1
-lightning-cli --network regtest --lightning-dir=ln1 newaddr
-#send bitcoin to that address
-bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin sendtoaddress <ADDRESS> <AMOUNT>
-#make sure to mine enough blocks
-bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin getnewaddress
-bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin generatetoaddress 100 <ADDRES>
-```
-Now you can open a channel :
-```shell
-#first you have to get the LN2_PUB_KEY ("id" in json)
-lightning-cli --network regtest --lightning-dir=ln2 getinfo
-#now you can connect LN1 to LN2
-lightning-cli --network regtest --lightning-dir=ln1 connect <LN2_PUB_KEY>@127.0.0.1:9001
-lightning-cli --network regtest --lightning-dir=ln1 fundchannel <LN2_PUB_KEY> 0.1btc
-#after that you should mine some blocks again
-bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin getnewaddress
-bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin generatetoaddress 100 <ADDRES>
-```
-### Using the client
-First you need to make sure that your regtest `bitcoind` has some coins that are mature. For that you can generate a few hundred blocks to your own wallet:
+
+First generate a few hundred blocks to you your regtest `bitcoind` wallet to ensure it has mature coins.
 
 ```shell
 ADDRESS="$(bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin getnewaddress)"
 bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin generatetoaddress 200 "$ADDRESS"
 ```
+
+Send your gateway Ligtning node some funds:
+
+```shell
+# Get address from gateway lightning node (we'll call it LN_ADDRESS)
+lightning-cli --network regtest --lightning-dir=ln1 newaddr
+
+# Send bitcoin to gateway lightning address
+bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin sendtoaddress <LN_ADDRESS> <AMOUNT>
+bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin generatetoaddress 1 $ADDRESS
+```
+
+Now you can open a channel:
+
+```shell
+# First you have to get the LN2_PUB_KEY ("id" in json)
+lightning-cli --network regtest --lightning-dir=ln2 getinfo
+
+# Now you can connect LN1 to LN2
+lightning-cli --network regtest --lightning-dir=ln1 connect <LN2_PUB_KEY>@127.0.0.1:9001
+lightning-cli --network regtest --lightning-dir=ln1 fundchannel <LN2_PUB_KEY> 0.1btc
+
+# Mine some blocks so the channel becomes active
+bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin generatetoaddress 10 $ADDRESS
+```
+
+### Using the client
 
 Then you can use the peg-in script to deposit funds. It contains comments that explain the deposit process.
 
@@ -161,21 +176,36 @@ minimint $ cargo run --bin mint-client --release -- cfg fetch
      Running `target/release/mint-client cfg fetch`
 Jun 15 15:02:06.264  INFO mint_client: Fetched coins from issuance 47d8f08710423c1e300854ecb6463ca6185e4b3890bbbb90fd1ff70c72e1ed18
 ```
-To pay a lightning invoice the `ln_gateway` must run :
+
+### Using the gateway
+
+To pay a Lightning invoice using ecash tokens via the gateway we must run the gateway itself:
+
 ```shell
 cargo run --bin ln_gateway --release cfg
 ```
-To get an invoice you can use ln2 :
+
+Generate a Lightning invoice from LN2, our non-gateway lightning node:
+
 ```shell
-#Make sure your peg-in created coins of small enough tiers. For now the client is not able to spend with change.
+# Make sure your peg-in created coins of small enough tiers. For now the client is not able to spend without exact change.
 lightning-cli --network regtest --lightning-dir=ln2 invoice 100000 test test 10m
 ```
-To pay the invoice : 
+
+Have LN2 non-gateway lightning node monitor the payment of this invoice. This command hangs until invoice is paid, so run it in another terminal window. Once paid, it will print out some information.
+
 ```shell
-cargo run --bin mint-client --release -- cfg ln-pay <INVOICE>
-#to check if the invoice got paid successfully you can use ln2
 lightning-cli --network regtest --lightning-dir=ln2 waitinvoice test
 ```
+
+Pay the invoice: 
+
+```shell
+cargo run --bin mint-client --release -- cfg ln-pay <INVOICE>
+```
+
+### Other options
+
 There also exist some other, more experimental commands that can be explored using the `--help` flag:
 
 ```

--- a/README.md
+++ b/README.md
@@ -60,9 +60,14 @@ cargo run --bin gw_configgen -- cfg /home/user/.lightning/regtest/lightning-rpc
 ```shell
 mkdir -p ln1 ln2
 ```
-Run the client config and set `ln1` as the gateway
+Run the client config and set `ln1` as the gateway. If you don't want to use Minimint with Lightning, you can skip the first command and hard-code a fake pubkey (e.g. `030160715ddbe8d4cd68e00fc910d6dac161fcfa457bfef4fd8bb93350cc2966aa`).
 ```shell
-cargo run --bin gw_configgen -- cfg "ln1/regtest/lightning-rpc"
+$ lightning-cli --network regtest --lightning-dir=ln1 getinfo
+{
+    "id": <pubkey>,
+    ...
+}
+$ cargo run --bin gw_configgen -- cfg "ln1/regtest/lightning-rpc" <pubkey>
 ```
 ### Running the mints
 A script for running all mints and a regtest `bitcoind` at once is provided at `scripts/startfed.sh`. Run it as follows:

--- a/ln-gateway/src/bin/gw_configgen.rs
+++ b/ln-gateway/src/bin/gw_configgen.rs
@@ -4,6 +4,7 @@ use mint_client::clients::gateway::GatewayClientConfig;
 use mint_client::ln::gateway::LightningGateway;
 use mint_client::ClientAndGatewayConfig;
 use rand::thread_rng;
+use secp256k1::PublicKey;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -11,6 +12,7 @@ use structopt::StructOpt;
 struct Opts {
     workdir: PathBuf,
     ln_rpc_path: PathBuf,
+    ln_node_pub_key: PublicKey,
 }
 
 fn main() {
@@ -21,7 +23,7 @@ fn main() {
 
     let mut rng = thread_rng();
     let ctx = secp256k1::Secp256k1::new();
-    let (_sk_ln, pk_ln) = ctx.generate_keypair(&mut rng);
+
     let (sk_fed, pk_fed) = ctx.generate_schnorrsig_keypair(&mut rng);
 
     let gateway_cfg = LnGatewayConfig {
@@ -41,7 +43,7 @@ fn main() {
         client: federation_client_cfg,
         gateway: LightningGateway {
             mint_pub_key: pk_fed,
-            node_pub_key: pk_ln,
+            node_pub_key: opts.ln_node_pub_key,
             api: "http://127.0.0.1:8080".to_string(),
         },
     };


### PR DESCRIPTION
Currently we just generate a fake Lightning node pubkey which makes receiving Lightning payments impossible.

As discussed on Telegram, this change allows us to both run the federation without requiring lightning (pass your own fake pubkey) or use the pubkey of a real node.