### PR TITLE
Core lightning plugin to intercept HTLCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cln-plugin"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2043841c090a404cb81b145c8ad3c66bae122ba722387fc322b93c157d596433"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "cln-rpc",
+ "futures",
+ "log",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.6.9",
+]
+
+[[package]]
 name = "cln-rpc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1598,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "async-trait",
+ "cln-plugin",
  "cln-rpc",
  "futures",
  "hex",
@@ -3269,6 +3288,17 @@ dependencies = [
  "proc-macro2 1.0.37",
  "quote 1.0.18",
  "syn 1.0.91",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.8",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,7 @@ dependencies = [
  "futures",
  "hex",
  "lightning-invoice",
+ "log",
  "minimint",
  "minimint-api",
  "mint-client",
@@ -1631,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -1851,6 +1852,7 @@ dependencies = [
  "hex",
  "lightning",
  "lightning-invoice",
+ "log",
  "minimint",
  "minimint-api",
  "miniscript",
@@ -3525,9 +3527,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
 dependencies = [
  "ctor",
  "erased-serde",

--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -27,3 +27,6 @@ tide = "0.16.0"
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }
 tokio = {version = "1.0", features = ["full"]}
+
+# FIXME: kept getting `Error: attempted to set a logger after the logging system was already initialized`
+log = "0.4.17"

--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 async-std = { version = "1.6.0", features = ["attributes", "tokio1"] }
 async-trait = "0.1.52"
 cln-rpc = "0.1"
+cln-plugin = "0.1.0"
 futures = "0.3.21"
 hex = "0.4.3"
 lightning-invoice = "0.14.0"

--- a/ln-gateway/src/bin/cln.rs
+++ b/ln-gateway/src/bin/cln.rs
@@ -15,22 +15,23 @@ async fn htlc_accepted_handler(
     _p: Plugin<()>,
     v: serde_json::Value,
 ) -> Result<serde_json::Value, Error> {
-    info!("htlc accepted: {}", v);
+    // TODO: actually do something here ...
+    info!("htlc_accepted observed");
 
-    return Ok(json!({
-        "result": "continue"
-    }));
-
-    // TODO: buy this from federation
-    let preimage = "0000000000000000000000000000000000000000000000000000000000000000";
+    // return Ok(json!({
+    //     "result": "continue"
+    // }));
 
     // If the preimage matches, complete the payment
     // Check that the amount is matches
     // You've lost ecash tokens, but gained lightning btc
-    // Ok(json!({
-    //   "result": "resolve",
-    //   "payment_key": preimage,
-    // }))
+
+    // TODO: buy this from federation
+    let preimage = "0000000000000000000000000000000000000000000000000000000000000000";
+    Ok(json!({
+      "result": "resolve",
+      "payment_key": preimage,
+    }))
 
     // Otherwise,
     // 1) Fail the payment on lightning
@@ -63,7 +64,7 @@ async fn pay_invoice(mut req: tide::Request<State>) -> tide::Result {
 async fn run_gateway(workdir: PathBuf) -> tide::Result<()> {
     // Give core-lightning some time to startup RPC socket (ln socket wasn't there ...)
     // FIXME: is there a better way?
-    tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(3000)).await;
 
     let cfg_path = workdir.join("gateway.json");
     let db_path = workdir.join("gateway.db");

--- a/ln-gateway/src/bin/cln.rs
+++ b/ln-gateway/src/bin/cln.rs
@@ -49,12 +49,6 @@ async fn pay_invoice(mut req: tide::Request<State>) -> tide::Result {
 }
 
 async fn run_gateway(workdir: PathBuf) -> tide::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .init();
-
     let cfg_path = workdir.join("gateway.json");
     let db_path = workdir.join("gateway.db");
     let cfg: LnGatewayConfig = load_from_file(&cfg_path);
@@ -78,6 +72,11 @@ async fn run_gateway(workdir: PathBuf) -> tide::Result<()> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
     if let Some(plugin) = Builder::new((), tokio::io::stdin(), tokio::io::stdout())
         .option(options::ConfigOption::new(
             "minimint-cfg",

--- a/ln-gateway/src/bin/cln.rs
+++ b/ln-gateway/src/bin/cln.rs
@@ -1,0 +1,108 @@
+#[macro_use]
+extern crate serde_json;
+use cln_plugin::{options, Builder, Error, Plugin};
+use ln_gateway::{LnGateway, LnGatewayConfig};
+use minimint::config::load_from_file;
+use minimint::modules::ln::contracts::ContractId;
+use std::{path::PathBuf, sync::Arc};
+use tide::Response;
+use tokio;
+use tracing::{debug, info, warn};
+use tracing_subscriber::EnvFilter;
+
+async fn htlc_accepted_handler(
+    _p: Plugin<()>,
+    v: serde_json::Value,
+) -> Result<serde_json::Value, Error> {
+    info!("htlc accepted: {}", v);
+
+    // TODO: buy this from federation
+    let preimage = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    Ok(json!({
+      "result": "resolve",
+      "payment_key": preimage,
+    }))
+}
+
+#[derive(Clone)]
+pub struct State {
+    gateway: Arc<LnGateway>,
+}
+
+async fn pay_invoice(mut req: tide::Request<State>) -> tide::Result {
+    debug!("Gateway received outgoing pay request");
+    let rng = rand::rngs::OsRng::new().unwrap();
+    let contract: ContractId = req.body_json().await?;
+    let State { ref gateway } = req.state();
+
+    debug!("Received request to pay invoice of contract {}", contract);
+
+    gateway
+        .pay_invoice(contract, rng)
+        .await
+        .map_err(|e| {
+            warn!("{:?}", e);
+            tide::Error::from_debug(e)
+        })
+        .map(|()| Response::new(200))
+}
+
+async fn run_gateway(workdir: PathBuf) -> tide::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let cfg_path = workdir.join("gateway.json");
+    let db_path = workdir.join("gateway.db");
+    let cfg: LnGatewayConfig = load_from_file(&cfg_path);
+    let db = sled::open(&db_path)
+        .unwrap()
+        .open_tree("mint-client")
+        .unwrap();
+
+    let gateway = LnGateway::from_config(Box::new(db), cfg).await;
+
+    let state = State {
+        gateway: Arc::new(gateway),
+    };
+
+    let mut app = tide::with_state(state);
+    app.at("/pay_invoice").post(pay_invoice);
+    app.listen("27.0.0.1:8080").await?;
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    if let Some(plugin) = Builder::new((), tokio::io::stdin(), tokio::io::stdout())
+        .option(options::ConfigOption::new(
+            "minimint-cfg",
+            // FIXME: cln_plugin doesn't yet support optional parameters
+            options::Value::String("default-dont-use".into()),
+            "minimint config directory",
+        ))
+        .hook("htlc_accepted", htlc_accepted_handler)
+        .start()
+        .await?
+    {
+        let workdir = match plugin.option("minimint-cfg").expect("minimint-cfg missing") {
+            options::Value::String(workdir) => {
+                // FIXME: cln_plugin doesn't yet support optional parameters
+                if &workdir == "default-done-use" {
+                    panic!("minimint-cfg option missing")
+                } else {
+                    PathBuf::from(workdir.clone())
+                }
+            }
+            _ => unreachable!(),
+        };
+        tokio::spawn(run_gateway(workdir.clone()));
+        plugin.join().await
+    } else {
+        Ok(())
+    }
+}

--- a/ln-gateway/src/bin/cln.rs
+++ b/ln-gateway/src/bin/cln.rs
@@ -6,36 +6,27 @@ use minimint::config::load_from_file;
 use minimint::modules::ln::contracts::ContractId;
 use std::{path::PathBuf, sync::Arc};
 use tide::Response;
-use tokio;
-// use tracing::{debug, info, warn};
-use log::{debug, info, warn};
-use tracing_subscriber::EnvFilter;
+
+use log::{debug, warn};
+// use tracing::{debug, warn};
+// use tracing_subscriber::EnvFilter;
 
 async fn htlc_accepted_handler(
     _p: Plugin<()>,
-    v: serde_json::Value,
+    _v: serde_json::Value,
 ) -> Result<serde_json::Value, Error> {
-    // TODO: actually do something here ...
-    info!("htlc_accepted observed");
+    debug!("htlc_accepted observed");
 
-    // return Ok(json!({
-    //     "result": "continue"
-    // }));
-
+    // TODO: buy this from federation
     // If the preimage matches, complete the payment
     // Check that the amount is matches
     // You've lost ecash tokens, but gained lightning btc
-
-    // TODO: buy this from federation
     let preimage = "0000000000000000000000000000000000000000000000000000000000000000";
+
     Ok(json!({
       "result": "resolve",
       "payment_key": preimage,
     }))
-
-    // Otherwise,
-    // 1) Fail the payment on lightning
-    // 2) Claw back your funds
 }
 
 #[derive(Clone)]
@@ -112,7 +103,7 @@ async fn main() -> Result<(), Error> {
                 if &workdir == "default-done-use" {
                     panic!("minimint-cfg option missing")
                 } else {
-                    PathBuf::from(workdir.clone())
+                    PathBuf::from(workdir)
                 }
             }
             _ => unreachable!(),

--- a/ln-gateway/src/bin/gw_configgen.rs
+++ b/ln-gateway/src/bin/gw_configgen.rs
@@ -4,6 +4,7 @@ use mint_client::clients::gateway::GatewayClientConfig;
 use mint_client::ln::gateway::LightningGateway;
 use mint_client::ClientAndGatewayConfig;
 use rand::thread_rng;
+use secp256k1::PublicKey;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -11,6 +12,7 @@ use structopt::StructOpt;
 struct Opts {
     workdir: PathBuf,
     ln_rpc_path: PathBuf,
+    ln_node_pub_key: PublicKey,
 }
 
 fn main() {
@@ -21,7 +23,7 @@ fn main() {
 
     let mut rng = thread_rng();
     let ctx = secp256k1::Secp256k1::new();
-    let (_sk_ln, pk_ln) = ctx.generate_keypair(&mut rng);
+
     let (sk_fed, pk_fed) = ctx.generate_schnorrsig_keypair(&mut rng);
 
     let gateway_cfg = LnGatewayConfig {
@@ -41,7 +43,7 @@ fn main() {
         client: federation_client_cfg,
         gateway: LightningGateway {
             mint_pub_key: pk_fed,
-            node_pub_key: pk_ln,
+            node_pub_key: opts.ln_node_pub_key,
             api: "http://127.0.0.1:8080".to_string(),
         },
     };

--- a/ln-gateway/src/lib.rs
+++ b/ln-gateway/src/lib.rs
@@ -12,8 +12,7 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::Mutex;
 use tokio::time::Instant;
-use tracing::{debug, instrument};
-use tracing::{error, warn};
+use tracing::{debug, error, instrument, warn};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LnGatewayConfig {

--- a/mint-client/Cargo.toml
+++ b/mint-client/Cargo.toml
@@ -31,3 +31,6 @@ thiserror = "1.0.23"
 tokio = { version = "1.0.1", features = ["full"] }
 tracing ="0.1.22"
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }
+
+# FIXME: kept getting `Error: attempted to set a logger after the logging system was already initialized`
+log = "0.4.17"

--- a/mint-client/src/clients/user.rs
+++ b/mint-client/src/clients/user.rs
@@ -18,6 +18,7 @@ use minimint::transaction as mint_tx;
 use minimint::transaction::{Output, TransactionItem};
 use minimint_api::db::batch::DbBatch;
 use minimint_api::db::Database;
+use minimint_api::module::http::Request;
 use minimint_api::{Amount, TransactionId};
 use minimint_api::{OutPoint, PeerId};
 use rand::{CryptoRng, RngCore};
@@ -85,6 +86,11 @@ impl UserClient {
                 .borrow_with_module_config(|cfg| &cfg.client.wallet),
             fee_consensus: self.context.config.client.fee_consensus.clone(), // TODO: remove or put into context
         }
+    }
+
+    // FIXME: we probably want a "gateway client"
+    pub fn gateway_api(&self) -> String {
+        self.context.config.gateway.api.clone()
     }
 
     pub async fn peg_in<R: RngCore + CryptoRng>(
@@ -300,7 +306,6 @@ impl UserClient {
 
     pub async fn fund_outgoing_ln_contract<R: RngCore + CryptoRng>(
         &self,
-        gateway: &LightningGateway,
         invoice: Invoice,
         mut rng: R,
     ) -> Result<ContractId, ClientError> {
@@ -314,7 +319,7 @@ impl UserClient {
             .create_outgoing_output(
                 batch.transaction(),
                 invoice,
-                gateway,
+                &self.context.config.gateway,
                 absolute_timelock as u32,
                 &mut rng,
             )

--- a/mint-client/src/clients/user.rs
+++ b/mint-client/src/clients/user.rs
@@ -4,7 +4,7 @@ use crate::ln::{LnClient, LnClientError};
 use crate::mint::{MintClient, MintClientError, SpendableCoin};
 use crate::wallet::{WalletClient, WalletClientError};
 use crate::{api, ClientAndGatewayConfig, OwnedClientContext};
-use bitcoin::{Address, Transaction};
+use bitcoin::{Address, PrivateKey, Transaction};
 use bitcoin_hashes::Hash;
 use lightning::ln::PaymentSecret;
 use lightning::routing::network_graph::RoutingFees;
@@ -21,7 +21,7 @@ use minimint_api::db::Database;
 use minimint_api::{Amount, TransactionId};
 use minimint_api::{OutPoint, PeerId};
 use rand::{CryptoRng, RngCore};
-use secp256k1_zkp::{All, Secp256k1};
+use secp256k1_zkp::{All, PublicKey, Secp256k1, SecretKey};
 use std::time::Duration;
 use thiserror::Error;
 
@@ -395,12 +395,19 @@ impl UserClient {
         mut rng: R,
     ) -> Result<Invoice, ClientError> {
         // TODO: do somehting with this private key ...
-        let (secret_key, public_key) = self.context.secp.generate_schnorrsig_keypair(&mut rng);
-        let raw_payment_secret = public_key.serialize();
+        // let (secret_key, public_key) = self.context.secp.generate_schnorrsig_keypair(&mut rng);
+        // let raw_payment_secret = public_key.serialize();
+
+        // Hard-coding for now
+        let raw_payment_secret = [0; 32];
+
         let payment_hash = bitcoin::secp256k1::hashes::sha256::Hash::hash(&raw_payment_secret);
         let payment_secret = PaymentSecret(raw_payment_secret);
         // Final route to the user's contract inside the federation
         let (node_secret_key, node_public_key) = self.context.secp.generate_keypair(&mut rng);
+        // let node_secret_key = SecretKey::from_slice(&[1; 31]).expect("couldn't create private key");
+        // let node_public_key = PublicKey::from_secret_key(&self.context.secp, &node_secret_key);
+
         log::info!("ephemeral node pubkey: {:?}", node_public_key);
         // How to route to gateway
         log::info!(

--- a/mint-client/src/clients/user.rs
+++ b/mint-client/src/clients/user.rs
@@ -1,5 +1,4 @@
 use crate::api::{ApiError, FederationApi};
-use crate::ln::gateway::LightningGateway;
 use crate::ln::{LnClient, LnClientError};
 use crate::mint::{MintClient, MintClientError, SpendableCoin};
 use crate::wallet::{WalletClient, WalletClientError};
@@ -18,7 +17,6 @@ use minimint::transaction as mint_tx;
 use minimint::transaction::{Output, TransactionItem};
 use minimint_api::db::batch::DbBatch;
 use minimint_api::db::Database;
-use minimint_api::module::http::Request;
 use minimint_api::{Amount, TransactionId};
 use minimint_api::{OutPoint, PeerId};
 use rand::{CryptoRng, RngCore};
@@ -86,11 +84,6 @@ impl UserClient {
                 .borrow_with_module_config(|cfg| &cfg.client.wallet),
             fee_consensus: self.context.config.client.fee_consensus.clone(), // TODO: remove or put into context
         }
-    }
-
-    // FIXME: we probably want a "gateway client"
-    pub fn gateway_api(&self) -> String {
-        self.context.config.gateway.api.clone()
     }
 
     pub async fn peg_in<R: RngCore + CryptoRng>(

--- a/mint-client/src/lib.rs
+++ b/mint-client/src/lib.rs
@@ -42,7 +42,7 @@ impl<CO> OwnedClientContext<CO> {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClientAndGatewayConfig {
     pub client: ClientConfig,
     pub gateway: LightningGateway,

--- a/mint-client/src/main.rs
+++ b/mint-client/src/main.rs
@@ -91,8 +91,9 @@ async fn main() {
     let mut rng = rand::rngs::OsRng::new().unwrap();
 
     let client = UserClient::new(cfg, Box::new(db), Default::default());
+
     // FIXME: ClientAndGatewayConfig can't be cloned and couldn't figure out how to access it via
-    // client.gateway or something because of the weird "context" stuff
+    // client.gateway because of the weird "context" stuff. So just re-initializing from file ...
     let cfg: ClientAndGatewayConfig = load_from_file(&cfg_path);
 
     match opts.command {

--- a/mint-client/src/main.rs
+++ b/mint-client/src/main.rs
@@ -92,10 +92,6 @@ async fn main() {
 
     let client = UserClient::new(cfg, Box::new(db), Default::default());
 
-    // FIXME: ClientAndGatewayConfig can't be cloned and couldn't figure out how to access it via
-    // client.gateway because of the weird "context" stuff. So just re-initializing from file ...
-    let cfg: ClientAndGatewayConfig = load_from_file(&cfg_path);
-
     match opts.command {
         Command::PegInAddress => {
             println!("{}", client.get_new_pegin_address(&mut rng))
@@ -151,7 +147,7 @@ async fn main() {
             let http = reqwest::Client::new();
 
             let contract_id = client
-                .fund_outgoing_ln_contract(&cfg.gateway, bolt11, &mut rng)
+                .fund_outgoing_ln_contract(bolt11, &mut rng)
                 .await
                 .expect("Not enough coins");
 
@@ -165,7 +161,7 @@ async fn main() {
                 "Funded outgoing contract, notifying gateway",
             );
 
-            http.post(&format!("{}/pay_invoice", &cfg.gateway.api))
+            http.post(&format!("{}/pay_invoice", &client.gateway_api()))
                 .json(&contract_id)
                 .timeout(Duration::from_secs(15))
                 .send()

--- a/mint-client/src/main.rs
+++ b/mint-client/src/main.rs
@@ -90,7 +90,7 @@ async fn main() {
 
     let mut rng = rand::rngs::OsRng::new().unwrap();
 
-    let client = UserClient::new(cfg, Box::new(db), Default::default());
+    let client = UserClient::new(cfg.clone(), Box::new(db), Default::default());
 
     match opts.command {
         Command::PegInAddress => {
@@ -161,7 +161,7 @@ async fn main() {
                 "Funded outgoing contract, notifying gateway",
             );
 
-            http.post(&format!("{}/pay_invoice", &client.gateway_api()))
+            http.post(&format!("{}/pay_invoice", &cfg.gateway.api))
                 .json(&contract_id)
                 .timeout(Duration::from_secs(15))
                 .send()


### PR DESCRIPTION
TLDR this PR turns `ln_gateway` into a core-lightning "plugin" so that it can intercept HTLCs using the [htlc_accepted](https://github.com/ElementsProject/lightning/blob/master/doc/PLUGINS.md#htlc_accepted) hook. In the future this will allow the gateway to buy the preimage from the federation and complete incoming lightning payments. Right now a preimage is hard-coded. I made a new file for this plugin since it's not really done yet ...

This PR also creates a new `UserClient::create_invoice(amount)` method to create a lightning invoice which will allow the gateway to receive payment and (eventually) figure out which preimage to buy from the federation.

Perhaps I should squash commits or break this up into a couple PRs? I'll leave some comments inline ...