### PR TITLE
Rust integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,10 +73,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions/checkout@v2.4.0
       - uses: cachix/install-nix-action@v15

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 cfg
 ln1
 ln2
+it
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +624,17 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clightningrpc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ae583d1efb5a0cb21d77ef53f872f104c872b5e05cc150b277d15afe13e974"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -1681,18 +1698,26 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 name = "minimint"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "async-trait",
  "bincode",
  "bitcoin",
+ "bitcoincore-rpc",
+ "clightningrpc",
+ "cln-rpc",
  "futures",
  "hbbft",
  "hex",
  "itertools",
+ "lightning",
+ "lightning-invoice",
+ "ln-gateway",
  "minimint-api",
  "minimint-derive",
  "minimint-ln",
  "minimint-mint",
  "minimint-wallet",
+ "mint-client",
  "rand 0.6.5",
  "rayon",
  "secp256k1-zkp",

--- a/README.md
+++ b/README.md
@@ -7,13 +7,19 @@
 If you want to learn more about the general idea go to [fedimint.org](https://fedimint.org/), beyond a high level explanation you can also find links to talks and blog posts at the bottom of the page.
 
 There exist three main communication channels for the project at the moment:
-* [FediMint telegram group:](https://t.me/fedimint) High level ideas, questions, cryptography discussions, etc., nothing code related though (to keep it low noise).
-* [MiniMint dev telegram group:](https://t.me/+uiO1s8gPIBE2YTU0) code related discussions that aren't a good fit for an issue, getting started, if you have weird compiler errors etc.
+* [FediMint telegram group](https://t.me/fedimint) - high level ideas, questions, cryptography discussions, etc., nothing code related though (to keep it low noise).
+* [MiniMint dev telegram group](https://t.me/+uiO1s8gPIBE2YTU0) - code related discussions that aren't a good fit for an issue, getting started, if you have weird compiler errors etc.
 * GitHub Issues: Things to fix, planned features, longer term architectural choices, etc. (something you want to remember in a week that would be lost in the noise on telegram)
 
 PRs fixing TODOs or issues are always welcome, it might be a good idea though to discuss more involved changes in an issue first to make sure the chosen approach fits into the bigger picture. Smaller PRs to fix typos, broken links etc. are also very welcome.
 
-To get started with the code base have a look at the next section. Happy hacking!
+To get started with development have a look at the:
+* [Architecture](docs/architecture.md) - high-level description of the codebase and design
+* [Integration tests](minimint/tests/TESTING.md) - instructions on how to write and run the integration tests
+* `scripts/final-checks.sh` - checks to run locally before opening a PR
+* `scripts/integrationtest.sh` - tests that will run automatically after a PR is opened
+
+Happy hacking!
 
 ## Running MiniMint locally
 

--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -26,11 +26,13 @@ async fn pay_invoice(mut req: tide::Request<State>) -> tide::Result {
 
     debug!(%contract, "Received request to pay invoice");
 
-    gateway
+    let result = gateway
         .pay_invoice(contract, rng)
         .await
         .map_err(tide::Error::from_debug)
-        .map(|()| Response::new(200))
+        .map(|()| Response::new(200));
+    gateway.await_contract_claimed(contract).await;
+    result
 }
 
 #[tokio::main]

--- a/minimint-api/src/db/batch.rs
+++ b/minimint-api/src/db/batch.rs
@@ -114,13 +114,9 @@ impl<'a, T> AccumulatorTx<'a, T> {
     ///  * Committing a sub-transaction makes its changes part of the parent transaction. Note that
     ///    the parent transaction may still be aborted leading to the removal of sub-transaction
     ///    items.
-    pub fn subtransaction<'b, 'c>(&'b mut self) -> AccumulatorTx<'c, T>
-    where
-        'a: 'b,
-        'b: 'c,
-    {
+    pub fn subtransaction(&mut self) -> AccumulatorTx<'_, T> {
         let checkpoint = self.batch.buffer.len();
-        AccumulatorTx::<'c, T> {
+        AccumulatorTx {
             batch: self.batch,
             checkpoint,
         }

--- a/minimint/Cargo.toml
+++ b/minimint/Cargo.toml
@@ -34,3 +34,13 @@ tokio = { version = "1.0.1", features = ["full"] }
 tokio-util = { version = "0.6.0", features = [ "compat" ] }
 tracing ="0.1.22"
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }
+
+[dev-dependencies]
+bitcoincore-rpc = "0.14.0"
+cln-rpc = "0.1"
+clightningrpc = "0.2.0"
+lightning-invoice = "0.14.0"
+mint-client = { path = "../mint-client" }
+ln-gateway = { path = "../ln-gateway" }
+lightning = "0.0.106"
+assert_matches = "1.5.0"

--- a/minimint/src/consensus/mod.rs
+++ b/minimint/src/consensus/mod.rs
@@ -54,8 +54,8 @@ where
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct AcceptedTransaction {
-    epoch: u64,
-    transaction: Transaction,
+    pub epoch: u64,
+    pub transaction: Transaction,
 }
 
 #[derive(Debug)]

--- a/minimint/tests/TESTING.md
+++ b/minimint/tests/TESTING.md
@@ -1,0 +1,94 @@
+# Integration Testing
+The Rust integration tests allow developers to test the interactions between the Minimint Federation, LN gateway, Clients, Lightning and Bitcoin.
+
+Note there is also a shell-based integration test in `scripts/integrationtest.sh` that will run the integration tests and some additional CLI-based tests prior to PRs being merged.
+
+## Writing tests
+Tests cases begin by initializing test fixtures with the number of federation nodes, the threshold that can misbehave, and the coin denomination tiers:
+
+```rust
+let (fed, user, bitcoin, gateway, ln) = fixtures(2, 0, &[sats(100), sats(1000)]).await;
+```
+
+Initialization will spawn API and HBBFT consensus threads for federation nodes starting at port `4000` then give you access to the following:
+- `fed`- control and inspect federation nodes and consensus
+- `user`- calls functions in the user client API to simulate minimint users
+- `bitcoin`- manipulate the shared Bitcoin network
+- `gateway`- calls functions in the gateway client API to simulate a gateway node
+- `lightning`- manipulate the gateway LN node and another connected LN node
+
+Calling functions on the clients can send requests to the federation's API and add new proposals to consensus:
+```rust
+user.client.peg_in(proof, tx, rng()).await.unwrap();
+```
+In order to simulate consensus we have to tell the federation how many epochs to run:
+```rust
+fed.run_consensus_epochs(2).await;
+```
+Note that because HBBFT and consensus processing are concurrent you must always add an additional epoch to consume a `ConsensusOutcome` before any newly proposed `ConsensusItems` will be processed.
+
+## Running tests
+Tests run by default with fake Lightning and Bitcoin services for fast concurrent testing that succeeds in any environment, but can also be run against real services.
+
+To run the tests in parallel against fake versions of Lightning and Bitcoin:
+```shell
+export MINIMINT_TEST_REAL=0
+cargo test -p minimint
+```
+
+When integration tests run they will output a debug log for each epoch:
+
+```
+- Epoch: 1 -
+  Peer 0: Wallet Block Height 10863
+  Peer 1: Wallet Block Height 10863
+
+- Epoch: 2 -
+  Peer 0: Transaction
+    Input: Wallet PegIn with TxId 49af58a2
+    Output: Mint Coins 4500000 msat
+...
+- Epoch: 12 -
+  Peer 0: Wallet Peg Out PSBT 94344c75 with 0 signatures
+  Peer 1: Wallet Peg Out PSBT 94344c75 with 0 signatures
+
+- Epoch: 13 -
+  Peer 0: Wallet Peg Out PSBT 94344c75 with 1 signatures
+  Peer 1: Wallet Peg Out PSBT 94344c75 with 1 signatures
+```
+which can be very useful for debugging what the minimint consensus is doing.
+You may wish to add the `--test-threads=1` flag or add `#[ignore]` to tests to prevent concurrent debug output.
+
+## Running with real services
+Make sure you've [installed](https://github.com/ElementsProject/lightning#installation) bitcoind and lightningd.
+Then you can run the following commands to start the services:
+```shell
+mkdir -p it/bitcoin
+bitcoind -regtest -fallbackfee=0.00001 -txindex -server -rpcuser=bitcoin -rpcpassword=bitcoin -datadir=it/bitcoin &
+
+# Wait for bitcoin to start before running Lightning
+until [ "$(bitcoin-cli -regtest -rpcuser=bitcoin -rpcpassword=bitcoin getblockchaininfo | jq -r '.chain')" == "regtest" ]; do
+  sleep 1
+done
+
+lightningd --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=it/ln1 --addr=127.0.0.1:9000 &
+lightningd --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=it/ln2 --addr=127.0.0.1:9001 &
+```
+
+You can now run the integration tests against real instances of Bitcoin and Lightning nodes, using one thread to avoid concurrency issues:
+
+```shell
+export MINIMINT_TEST_REAL=1
+export MINIMINT_TEST_DIR=$PWD/it/
+cargo test -p minimint -- --test-threads=1
+```
+
+The first time the tests run it will take several seconds for the LN gateway to fund a channel.
+Subsequent tests should start up relatively fast.
+
+If you wish to clean-up the services you can run:
+```shell
+killall bitcoind
+killall lightningd
+rm -rf it
+```

--- a/minimint/tests/fixture/fake.rs
+++ b/minimint/tests/fixture/fake.rs
@@ -1,0 +1,235 @@
+use std::iter::repeat;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use bitcoin::hash_types::Txid;
+use bitcoin::hashes::{sha256, Hash};
+use bitcoin::util::merkleblock::PartialMerkleTree;
+use bitcoin::{
+    ecdsa, secp256k1, Address, Block, BlockHash, BlockHeader, Network, Transaction, TxOut,
+};
+use lightning::ln::PaymentSecret;
+use lightning_invoice::{Currency, Invoice, InvoiceBuilder};
+use rand::rngs::OsRng;
+
+use ln_gateway::ln::{LightningError, LnRpc};
+use minimint_api::Amount;
+use minimint_wallet::bitcoind::BitcoindRpc;
+use minimint_wallet::txoproof::TxOutProof;
+use minimint_wallet::Feerate;
+
+use crate::fixture::{BitcoinTest, LightningTest};
+
+#[derive(Clone, Debug)]
+pub struct FakeLightningTest {
+    pub gateway_node_pub_key: secp256k1::PublicKey,
+    gateway_node_sec_key: secp256k1::SecretKey,
+    amount_sent: Arc<Mutex<u64>>,
+}
+
+impl FakeLightningTest {
+    const PREIMAGE: [u8; 32] = [1; 32];
+
+    pub fn new() -> Self {
+        let ctx = bitcoin::secp256k1::Secp256k1::new();
+        let (gateway_node_sec_key, gateway_node_pub_key) =
+            ctx.generate_keypair(&mut OsRng::new().unwrap());
+        let amount_sent = Arc::new(Mutex::new(0));
+
+        FakeLightningTest {
+            gateway_node_pub_key,
+            gateway_node_sec_key,
+            amount_sent,
+        }
+    }
+}
+
+impl LightningTest for FakeLightningTest {
+    fn invoice(&self, amount: Amount) -> Invoice {
+        let ctx = bitcoin::secp256k1::Secp256k1::new();
+
+        InvoiceBuilder::new(Currency::Regtest)
+            .description("".to_string())
+            .payment_hash(sha256::Hash::hash(&FakeLightningTest::PREIMAGE))
+            .current_timestamp()
+            .min_final_cltv_expiry(0)
+            .payment_secret(PaymentSecret([0; 32]))
+            .amount_milli_satoshis(amount.milli_sat)
+            .build_signed(|m| ctx.sign_recoverable(m, &self.gateway_node_sec_key))
+            .unwrap()
+    }
+
+    fn amount_sent(&self) -> Amount {
+        Amount::from_msat(*self.amount_sent.lock().unwrap())
+    }
+}
+
+#[async_trait]
+impl LnRpc for FakeLightningTest {
+    async fn pay(
+        &self,
+        invoice_str: &str,
+        _max_delay: u64,
+        _max_fee_percent: f64,
+    ) -> Result<[u8; 32], LightningError> {
+        let invoice: Invoice = invoice_str.parse().unwrap();
+        *self.amount_sent.lock().unwrap() += invoice.amount_milli_satoshis().unwrap();
+
+        Ok(FakeLightningTest::PREIMAGE)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct FakeBitcoinTest {
+    blocks: Arc<Mutex<Vec<Block>>>,
+    pending: Arc<Mutex<Vec<Transaction>>>,
+}
+
+impl FakeBitcoinTest {
+    pub fn new() -> Self {
+        FakeBitcoinTest {
+            blocks: Arc::new(Mutex::new(vec![])),
+            pending: Arc::new(Mutex::new(vec![])),
+        }
+    }
+
+    fn pending_merkle_tree(pending: &Vec<Transaction>) -> PartialMerkleTree {
+        let txs = pending.iter().map(|tx| tx.txid()).collect::<Vec<Txid>>();
+        let matches = repeat(true).take(txs.len()).collect::<Vec<bool>>();
+        PartialMerkleTree::from_txids(txs.as_slice(), matches.as_slice())
+    }
+
+    fn new_transaction(out: Vec<TxOut>) -> Transaction {
+        Transaction {
+            version: 0,
+            lock_time: 0,
+            input: vec![],
+            output: out,
+        }
+    }
+
+    fn mine_block(blocks: &mut Vec<Block>, pending: &mut Vec<Transaction>) {
+        let root = BlockHash::hash(&[0]);
+        // all blocks need at least one transaction
+        if pending.len() == 0 {
+            pending.push(Self::new_transaction(vec![]));
+        }
+        let merkle_root = Self::pending_merkle_tree(&pending)
+            .extract_matches(&mut vec![], &mut vec![])
+            .unwrap();
+        let block = Block {
+            header: BlockHeader {
+                version: 0,
+                prev_blockhash: blocks.last().map(|b| b.header.block_hash()).unwrap_or(root),
+                merkle_root,
+                time: 0,
+                bits: 0,
+                nonce: 0,
+            },
+            txdata: pending.clone(),
+        };
+        pending.clear();
+        blocks.push(block);
+    }
+}
+
+impl BitcoinTest for FakeBitcoinTest {
+    fn mine_blocks(&self, block_num: u64) {
+        let mut blocks = self.blocks.lock().unwrap();
+        let mut pending = self.pending.lock().unwrap();
+
+        for _ in 1..=block_num {
+            FakeBitcoinTest::mine_block(&mut blocks, &mut pending);
+        }
+    }
+
+    fn send_and_mine_block(
+        &self,
+        address: &Address,
+        amount: bitcoin::Amount,
+    ) -> (TxOutProof, Transaction) {
+        let mut blocks = self.blocks.lock().unwrap();
+        let mut pending = self.pending.lock().unwrap();
+
+        let transaction = FakeBitcoinTest::new_transaction(vec![TxOut {
+            value: amount.as_sat(),
+            script_pubkey: address.payload.script_pubkey(),
+        }]);
+
+        pending.push(transaction.clone());
+        let merkle_proof = FakeBitcoinTest::pending_merkle_tree(&pending);
+
+        FakeBitcoinTest::mine_block(&mut blocks, &mut pending);
+        let block_header = blocks.last().unwrap().header;
+
+        (
+            TxOutProof {
+                block_header,
+                merkle_proof,
+            },
+            transaction,
+        )
+    }
+
+    fn get_new_address(&self) -> Address {
+        let ctx = bitcoin::secp256k1::Secp256k1::new();
+        let (_, public_key) = ctx.generate_keypair(&mut OsRng::new().unwrap());
+
+        Address::p2wpkh(&ecdsa::PublicKey::new(public_key), Network::Regtest).unwrap()
+    }
+
+    fn mine_block_and_get_received(&self, address: &Address) -> Amount {
+        self.mine_blocks(1);
+        let sats = self
+            .blocks
+            .lock()
+            .unwrap()
+            .clone()
+            .into_iter()
+            .flat_map(|block| block.txdata.into_iter().flat_map(|tx| tx.output.clone()))
+            .find(|out| out.script_pubkey == address.payload.script_pubkey())
+            .unwrap()
+            .value
+            .clone();
+        Amount::from_sat(sats)
+    }
+}
+
+#[async_trait]
+impl BitcoindRpc for FakeBitcoinTest {
+    async fn get_network(&self) -> Network {
+        Network::Regtest
+    }
+
+    async fn get_block_height(&self) -> u64 {
+        self.blocks.lock().unwrap().len() as u64
+    }
+
+    async fn get_block_hash(&self, height: u64) -> BlockHash {
+        self.blocks.lock().unwrap()[(height - 1) as usize]
+            .header
+            .block_hash()
+            .clone()
+    }
+
+    async fn get_block(&self, hash: &BlockHash) -> Block {
+        self.blocks
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|block| hash.clone() == block.header.block_hash())
+            .unwrap()
+            .clone()
+    }
+
+    async fn get_fee_rate(&self, _confirmation_target: u16) -> Option<Feerate> {
+        None
+    }
+
+    async fn submit_transaction(&self, transaction: Transaction) {
+        let mut pending = self.pending.lock().unwrap();
+        if !pending.contains(&transaction) {
+            pending.push(transaction);
+        }
+    }
+}

--- a/minimint/tests/fixture/mod.rs
+++ b/minimint/tests/fixture/mod.rs
@@ -1,0 +1,594 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::env;
+use std::iter::repeat;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::atomic::AtomicU16;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use bitcoin::{secp256k1, Address, Transaction};
+use cln_rpc::ClnRpc;
+use futures::future::join_all;
+use itertools::Itertools;
+use lightning_invoice::Invoice;
+use rand::rngs::OsRng;
+use tokio::spawn;
+use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+
+use fake::{FakeBitcoinTest, FakeLightningTest};
+use ln_gateway::ln::LnRpc;
+use ln_gateway::LnGateway;
+use minimint::config::ServerConfigParams;
+use minimint::config::{ClientConfig, FeeConsensus, ServerConfig};
+use minimint::consensus::{ConsensusItem, ConsensusOutcome, FediMintConsensus};
+use minimint::transaction::{Input, Output};
+use minimint::MinimintServer;
+use minimint_api::config::GenerateConfig;
+use minimint_api::db::batch::DbBatch;
+use minimint_api::db::mem_impl::MemDatabase;
+use minimint_api::db::Database;
+use minimint_api::{Amount, FederationModule, OutPoint, PeerId};
+use minimint_ln::contracts::Contract;
+use minimint_ln::{ContractOrOfferOutput, ContractOutput};
+use minimint_mint::PartiallySignedRequest;
+use minimint_wallet::bitcoind::BitcoindRpc;
+use minimint_wallet::config::WalletConfig;
+use minimint_wallet::db::UnsignedTransactionKey;
+use minimint_wallet::txoproof::TxOutProof;
+use minimint_wallet::{Wallet, WalletConsensusItem};
+use mint_client::api::HttpFederationApi;
+use mint_client::clients::gateway::{GatewayClient, GatewayClientConfig};
+use mint_client::ln::gateway::LightningGateway;
+use mint_client::UserClient;
+use real::{RealBitcoinTest, RealLightningTest};
+
+mod fake;
+mod real;
+
+static BASE_PORT: AtomicU16 = AtomicU16::new(4000 as u16);
+
+// Helper functions for easier test writing
+pub fn rng() -> OsRng {
+    OsRng::new().unwrap()
+}
+
+pub fn sats(amount: u64) -> Amount {
+    Amount::from_sat(amount)
+}
+
+/// Generates the fixtures for an integration test and spawns API and HBBFT consensus threads for
+/// federation nodes starting at port 4000.
+pub async fn fixtures(
+    num_peers: u16,
+    max_evil_threshold: usize,
+    amount_tiers: &[Amount],
+) -> (
+    FederationTest,
+    UserTest,
+    Box<dyn BitcoinTest>,
+    GatewayTest,
+    Box<dyn LightningTest>,
+) {
+    let base_port = BASE_PORT.fetch_add(num_peers * 2, Ordering::Relaxed);
+
+    // in case we need to output logs using 'cargo test -- --nocapture'
+    if base_port == 4000 {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| EnvFilter::new("info,tide=error")),
+            )
+            .init();
+    }
+
+    let params = ServerConfigParams {
+        hbbft_base_port: base_port,
+        api_base_port: base_port + num_peers,
+        amount_tiers: amount_tiers.to_vec(),
+    };
+    let peers = (0..num_peers as u16).map(PeerId::from).collect::<Vec<_>>();
+
+    let (server_config, client_config) = ServerConfig::trusted_dealer_gen(
+        &peers,
+        max_evil_threshold,
+        &params,
+        OsRng::new().unwrap(),
+    );
+
+    match env::var("MINIMINT_TEST_REAL") {
+        Ok(s) if s == "1" => {
+            info!("Testing with REAL Bitcoin and Lightning services");
+            let dir =
+                env::var("MINIMINT_TEST_DIR").expect("Must have test dir defined for real tests");
+            let wallet_config = server_config.iter().last().unwrap().1.wallet.clone();
+            let bitcoin_rpc = Wallet::bitcoind(wallet_config.clone());
+            let bitcoin = RealBitcoinTest::new(wallet_config);
+            let socket_gateway = PathBuf::from(dir.clone()).join("ln1/regtest/lightning-rpc");
+            let socket_other = PathBuf::from(dir).join("ln2/regtest/lightning-rpc");
+            let lightning =
+                RealLightningTest::new(socket_gateway.clone(), socket_other.clone(), &bitcoin)
+                    .await;
+            let lightning_rpc = Mutex::new(
+                ClnRpc::new(socket_gateway.clone())
+                    .await
+                    .expect("connect to ln_socket"),
+            );
+            let fed = FederationTest::new(server_config.clone(), &bitcoin_rpc).await;
+            let user = UserTest::new(client_config.clone(), peers);
+            let gateway = GatewayTest::new(
+                Box::new(lightning_rpc),
+                client_config,
+                lightning.gateway_node_pub_key,
+            )
+            .await;
+
+            (fed, user, Box::new(bitcoin), gateway, Box::new(lightning))
+        }
+        _ => {
+            info!("Testing with FAKE Bitcoin and Lightning services");
+            let bitcoin = FakeBitcoinTest::new();
+            let bitcoin_rpc = || Box::new(bitcoin.clone()) as Box<dyn BitcoindRpc>;
+            let lightning = FakeLightningTest::new();
+            let fed = FederationTest::new(server_config.clone(), &bitcoin_rpc).await;
+            let user = UserTest::new(client_config.clone(), peers);
+            let gateway = GatewayTest::new(
+                Box::new(lightning.clone()),
+                client_config,
+                lightning.gateway_node_pub_key,
+            )
+            .await;
+
+            (fed, user, Box::new(bitcoin), gateway, Box::new(lightning))
+        }
+    }
+}
+
+pub trait BitcoinTest {
+    /// Mines a given number of blocks
+    fn mine_blocks(&self, block_num: u64);
+
+    /// Send some bitcoin to an address then mine a block to confirm it.
+    /// Returns the proof that the transaction occurred.
+    fn send_and_mine_block(
+        &self,
+        address: &Address,
+        amount: bitcoin::Amount,
+    ) -> (TxOutProof, Transaction);
+
+    /// Returns a new address.
+    fn get_new_address(&self) -> Address;
+
+    /// Mine a block to include any pending transactions then get the amount received to an address
+    fn mine_block_and_get_received(&self, address: &Address) -> Amount;
+}
+
+pub trait LightningTest {
+    /// Creates an invoice from a non-gateway LN node
+    fn invoice(&self, amount: Amount) -> Invoice;
+
+    /// Returns the amount that the gateway LN node has sent
+    fn amount_sent(&self) -> Amount;
+}
+
+pub struct GatewayTest {
+    pub server: LnGateway,
+    pub keys: LightningGateway,
+    pub user_client: UserClient,
+    pub client: Arc<GatewayClient>,
+}
+
+impl GatewayTest {
+    async fn new(
+        ln_client: Box<dyn LnRpc>,
+        client: ClientConfig,
+        node_pub_key: secp256k1::PublicKey,
+    ) -> Self {
+        let mut rng = OsRng::new().unwrap();
+        let ctx = bitcoin::secp256k1::Secp256k1::new();
+        let (secret_key_fed, public_key_fed) = ctx.generate_schnorrsig_keypair(&mut rng);
+
+        let federation_client = GatewayClientConfig {
+            common: client.clone(),
+            redeem_key: secret_key_fed,
+            timelock_delta: 10,
+        };
+
+        let keys = LightningGateway {
+            mint_pub_key: public_key_fed,
+            node_pub_key,
+            api: "".to_string(),
+        };
+
+        let database = Box::new(MemDatabase::new());
+        let user_client = UserClient::new(client, database.clone(), Default::default());
+
+        let client = Arc::new(GatewayClient::new(federation_client, database.clone()));
+        let server = LnGateway::new(client.clone(), ln_client).await;
+
+        GatewayTest {
+            server,
+            keys,
+            user_client,
+            client,
+        }
+    }
+}
+
+pub struct UserTest {
+    pub client: UserClient,
+    config: ClientConfig,
+    database: Box<dyn Database>,
+}
+
+impl UserTest {
+    /// Returns a new user client connected to a subset of peers.
+    pub fn new_client(&self, peers: &[u16]) -> Self {
+        let peers = peers
+            .iter()
+            .map(|i| PeerId::from(*i))
+            .collect::<Vec<PeerId>>();
+        Self::new(self.config.clone(), peers)
+    }
+
+    /// Returns the amount denominations of all coins from lowest to highest
+    pub fn coin_amounts(&self) -> Vec<Amount> {
+        self.client
+            .coins()
+            .coins
+            .into_iter()
+            .flat_map(|(a, c)| repeat(a).take(c.len()))
+            .sorted()
+            .collect::<Vec<Amount>>()
+    }
+
+    /// Returns sum total of all coins
+    pub fn total_coins(&self) -> Amount {
+        self.client.coins().amount()
+    }
+
+    fn new(config: ClientConfig, peers: Vec<PeerId>) -> Self {
+        let api = Box::new(HttpFederationApi::new(
+            config
+                .api_endpoints
+                .iter()
+                .enumerate()
+                .filter(|(id, _)| peers.contains(&PeerId::from(*id as u16)))
+                .map(|(id, url)| {
+                    (
+                        PeerId::from(id as u16),
+                        url.parse().expect("Invalid URL in config"),
+                    )
+                })
+                .collect(),
+        ));
+
+        let database = Box::new(MemDatabase::new());
+        let client =
+            UserClient::new_with_api(config.clone(), database.clone(), api, Default::default());
+
+        UserTest {
+            client,
+            config,
+            database,
+        }
+    }
+}
+
+pub struct FederationTest {
+    servers: Vec<Rc<RefCell<ServerTest>>>,
+    last_consensus_items: RefCell<Vec<ConsensusItem>>,
+    pub wallet: WalletConfig,
+    pub fee_consensus: FeeConsensus,
+}
+
+struct ServerTest {
+    outcome_receiver: Receiver<ConsensusOutcome>,
+    proposal_sender: Sender<Vec<ConsensusItem>>,
+    consensus: Arc<FediMintConsensus<OsRng>>,
+    cfg: ServerConfig,
+    bitcoin_rpc: Box<dyn BitcoindRpc>,
+    database: Arc<dyn Database>,
+}
+
+impl FederationTest {
+    /// Returns the items that were in the last consensus
+    /// Filters out redundant consensus rounds where the block height doesn't change
+    pub fn last_consensus(&self) -> Vec<ConsensusItem> {
+        self.last_consensus_items.borrow().clone()
+    }
+
+    /// Returns a fixture that only calls on a subset of the peers.  Note that PeerIds are always
+    /// starting at 0 in tests.
+    pub fn subset_peers(&self, peers: &[u16]) -> Self {
+        let peers = peers
+            .iter()
+            .map(|i| PeerId::from(*i))
+            .collect::<Vec<PeerId>>();
+
+        FederationTest {
+            servers: self
+                .servers
+                .iter()
+                .filter(|s| peers.contains(&s.as_ref().borrow().cfg.identity))
+                .map(Rc::clone)
+                .collect(),
+            wallet: self.wallet.clone(),
+            fee_consensus: self.fee_consensus.clone(),
+            last_consensus_items: self.last_consensus_items.clone(),
+        }
+    }
+
+    /// Inserts coins directly into the databases of federation nodes, runs consensus to sign them
+    /// then fetches the coins for the user client.
+    pub async fn mint_coins_for_user(&self, user: &UserTest, amount: Amount) {
+        let (finalization, coins) = user
+            .client
+            .mint_client()
+            .create_coin_output(amount.into(), OsRng::new().unwrap());
+        let out_point = OutPoint {
+            txid: Default::default(),
+            out_idx: 0,
+        };
+        for server in &self.servers {
+            let mut batch = DbBatch::new();
+            let mut batch_tx = batch.transaction();
+            let transaction = minimint::transaction::Transaction {
+                inputs: vec![],
+                outputs: vec![Output::Mint(coins.clone())],
+                signature: None,
+            };
+
+            batch_tx.append_insert(
+                minimint::db::AcceptedTransactionKey(out_point.txid),
+                minimint::consensus::AcceptedTransaction {
+                    epoch: 0,
+                    transaction,
+                },
+            );
+
+            batch_tx.commit();
+            server
+                .borrow_mut()
+                .consensus
+                .mint
+                .apply_output(batch.transaction(), &coins, out_point)
+                .unwrap();
+            server.borrow_mut().database.apply_batch(batch).unwrap();
+        }
+        let mut batch = DbBatch::new();
+        user.client.mint_client().save_coin_finalization_data(
+            batch.transaction(),
+            out_point,
+            finalization,
+        );
+        user.database.apply_batch(batch).unwrap();
+
+        self.run_consensus_epochs(2).await;
+        user.client.fetch_all_coins().await.unwrap();
+    }
+
+    /// Has every federation node broadcast any transactions pending to the Bitcoin network, otherwise
+    /// transactions will only get broadcast every 10 seconds.
+    pub async fn broadcast_transactions(&self) {
+        for server in &self.servers {
+            let s = server.as_ref().borrow();
+            minimint_wallet::broadcast_pending_tx(&s.database, s.bitcoin_rpc.as_ref()).await;
+        }
+    }
+
+    /// Has every federation node process the consensus outcome from the HBBFT thread then send new
+    /// consensus proposals to the HBBFT thread.  Anything currently pending will take an additional
+    /// epoch to get processed.
+    pub async fn run_consensus_epochs(&self, epochs: usize) {
+        for _ in 0..(epochs) {
+            for server in &self.servers {
+                let mut s = server.borrow_mut();
+                let height = s.consensus.wallet.consensus_height();
+                let consensus_outcome = s.outcome_receiver.recv().await.expect("other thread died");
+
+                // only need to update last_consensus_items and print one output since consensus is always the same
+                if s.cfg.identity == PeerId::from(0) {
+                    let filtered_consensus =
+                        FederationTest::remove_redundant_round_items(&consensus_outcome, height);
+                    let new_items = filtered_consensus
+                        .contributions
+                        .values()
+                        .flat_map(|items| items.clone());
+                    *self.last_consensus_items.borrow_mut() = new_items.collect();
+                    warn!(
+                        "{}",
+                        FederationTest::epoch_debug_message(&filtered_consensus, &s.database)
+                    )
+                }
+
+                minimint::run_consensus_epoch(
+                    &s.consensus,
+                    consensus_outcome,
+                    &s.proposal_sender,
+                    &s.cfg,
+                    0,
+                )
+                .await;
+            }
+        }
+    }
+
+    async fn new(
+        server_config: BTreeMap<PeerId, ServerConfig>,
+        bitcoin_gen: &impl Fn() -> Box<dyn BitcoindRpc>,
+    ) -> Self {
+        let servers = join_all(server_config.values().map(|cfg| async move {
+            let bitcoin_rpc = bitcoin_gen();
+            let database = Arc::new(MemDatabase::new());
+
+            let MinimintServer {
+                outcome_sender,
+                proposal_receiver,
+                outcome_receiver,
+                proposal_sender,
+                mint_consensus,
+                cfg,
+            } = minimint::minimint_server_with(cfg.clone(), database.clone(), bitcoin_gen).await;
+
+            let initial_cis = mint_consensus.get_consensus_proposal().await;
+            spawn(minimint::net::api::run_server(
+                cfg.clone(),
+                mint_consensus.clone(),
+            ));
+            spawn(minimint::hbbft(
+                outcome_sender,
+                proposal_receiver,
+                cfg.clone(),
+                initial_cis,
+                OsRng::new().unwrap(),
+            ));
+
+            Rc::new(RefCell::new(ServerTest {
+                outcome_receiver,
+                proposal_sender,
+                bitcoin_rpc,
+                consensus: mint_consensus,
+                cfg,
+                database,
+            }))
+        }))
+        .await;
+
+        let server_config = server_config.iter().last().unwrap().1.clone();
+        let fee_consensus = server_config.fee_consensus;
+        let wallet = server_config.wallet;
+        let last_consensus_items = RefCell::new(vec![]);
+
+        FederationTest {
+            servers,
+            fee_consensus,
+            wallet,
+            last_consensus_items,
+        }
+    }
+
+    fn remove_redundant_round_items(
+        consensus: &ConsensusOutcome,
+        prev_block_height: Option<u32>,
+    ) -> ConsensusOutcome {
+        let mut contributions = BTreeMap::new();
+
+        for (peer, items) in consensus.contributions.iter() {
+            let filtered = items
+                .into_iter()
+                .filter(|item| match item {
+                    ConsensusItem::Wallet(WalletConsensusItem::RoundConsensus(
+                        minimint_wallet::RoundConsensusItem { block_height, .. },
+                    )) => Some(block_height.clone()) != prev_block_height,
+                    _ => true,
+                })
+                .cloned()
+                .collect();
+            contributions.insert(peer.clone(), filtered);
+        }
+
+        ConsensusOutcome {
+            epoch: consensus.epoch,
+            contributions,
+        }
+    }
+
+    // outputs a useful debug message for epochs indicating what happened
+    fn epoch_debug_message(consensus: &ConsensusOutcome, database: &Arc<dyn Database>) -> String {
+        let mut debug = format!("\n- Epoch: {} -", consensus.epoch);
+
+        for (peer, items) in consensus.contributions.iter() {
+            for item in items {
+                let item_debug = Self::item_debug_message(item, database);
+                debug.push_str(&format!("\n  Peer {}: {}", peer, item_debug));
+            }
+        }
+        debug
+    }
+
+    fn item_debug_message(item: &ConsensusItem, database: &Arc<dyn Database>) -> String {
+        match item {
+            ConsensusItem::Wallet(WalletConsensusItem::RoundConsensus(
+                minimint_wallet::RoundConsensusItem { block_height, .. },
+            )) => format!("Wallet Block Height {}", block_height),
+            ConsensusItem::Wallet(WalletConsensusItem::PegOutSignature(
+                minimint_wallet::PegOutSignatureItem { txid, .. },
+            )) => {
+                let sigs = database
+                    .get_value(&UnsignedTransactionKey(txid.clone()))
+                    .unwrap()
+                    .unwrap()
+                    .inputs
+                    .first()
+                    .unwrap()
+                    .partial_sigs
+                    .len();
+                format!("Wallet Peg Out PSBT {:.8} with {} signatures", txid, sigs)
+            }
+            ConsensusItem::Mint(PartiallySignedRequest {
+                out_point,
+                partial_signature,
+            }) => format!(
+                "Mint Signed Coins {} with TxId {:.8}",
+                partial_signature.0.amount(),
+                out_point.txid
+            ),
+            ConsensusItem::LN(minimint_ln::DecryptionShareCI { contract_id, .. }) => {
+                format!("LN Decrytion Share for contract {:.8}", contract_id)
+            }
+            ConsensusItem::Transaction(minimint::transaction::Transaction {
+                inputs,
+                outputs,
+                ..
+            }) => {
+                let mut tx_debug = format!("Transaction");
+                for input in inputs.iter() {
+                    let input_debug = match input {
+                        Input::Mint(t) => format!("Mint Coins {}", t.amount()),
+                        Input::Wallet(t) => {
+                            format!("Wallet PegIn with TxId {:.8}", t.outpoint().txid)
+                        }
+                        Input::LN(t) => {
+                            format!("LN Contract {} with id {:.8}", t.amount, t.crontract_id)
+                        }
+                    };
+                    tx_debug.push_str(&format!("\n    Input: {}", input_debug));
+                }
+                for output in outputs.iter() {
+                    let output_debug = match output {
+                        Output::Mint(t) => format!("Mint Coins {}", t.amount()),
+                        Output::Wallet(t) => format!(
+                            "Wallet PegOut {} to address {:.8}",
+                            t.amount,
+                            t.recipient.to_string()
+                        ),
+                        Output::LN(ContractOrOfferOutput::Offer(o)) => {
+                            format!("LN Offer for {} with hash {:.8}", o.amount, o.hash)
+                        }
+                        Output::LN(ContractOrOfferOutput::Contract(ContractOutput {
+                            amount,
+                            contract,
+                        })) => match contract {
+                            Contract::Account(a) => {
+                                format!("LN Account Contract for {} key {:.8}", amount, a.key)
+                            }
+                            Contract::Incoming(a) => {
+                                format!("LN Incoming Contract for {} hash {:.8}", amount, a.hash)
+                            }
+                            Contract::Outgoing(a) => {
+                                format!("LN Outgoing Contract for {} hash {:.8}", amount, a.hash)
+                            }
+                        },
+                    };
+                    tx_debug.push_str(&format!("\n    Output: {}", output_debug));
+                }
+                tx_debug
+            }
+        }
+    }
+}

--- a/minimint/tests/fixture/real.rs
+++ b/minimint/tests/fixture/real.rs
@@ -1,0 +1,235 @@
+use std::io::Cursor;
+use std::ops::Sub;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::thread;
+use std::time::Duration;
+
+use bitcoin::secp256k1;
+use bitcoin::{Address, Transaction};
+use bitcoincore_rpc::Client;
+use bitcoincore_rpc::{Auth, RpcApi};
+use clightningrpc::responses::NetworkAddress;
+use clightningrpc::{responses, LightningRPC};
+use lightning_invoice::Invoice;
+use minimint_api::Amount;
+use serde::Serialize;
+use tracing::{info, warn};
+
+use minimint_api::encoding::Decodable;
+use minimint_wallet::config::WalletConfig;
+use minimint_wallet::txoproof::TxOutProof;
+
+use crate::fixture::{BitcoinTest, LightningTest};
+
+pub struct RealLightningTest {
+    rpc_gateway: LightningRPC,
+    rpc_other: LightningRPC,
+    initial_balance: Amount,
+    pub gateway_node_pub_key: secp256k1::PublicKey,
+}
+
+impl LightningTest for RealLightningTest {
+    fn invoice(&self, amount: Amount) -> Invoice {
+        let random: u64 = rand::random();
+        let invoice = self
+            .rpc_other
+            .invoice(amount.milli_sat, &random.to_string(), "", None)
+            .unwrap();
+        Invoice::from_str(&invoice.bolt11).unwrap()
+    }
+
+    fn amount_sent(&self) -> Amount {
+        self.initial_balance
+            .sub(Self::channel_balance(&self.rpc_gateway))
+    }
+}
+
+impl RealLightningTest {
+    pub async fn new(
+        socket_gateway: PathBuf,
+        socket_other: PathBuf,
+        bitcoin: &dyn BitcoinTest,
+    ) -> Self {
+        let rpc_other = LightningRPC::new(socket_other);
+        let mut rpc_gateway = LightningRPC::new(socket_gateway);
+
+        // ensure the lightning node has a channel with > 1M sats
+        if Self::channel_balance(&rpc_gateway).milli_sat < 1000 * 1000 * 1000 {
+            info!("Attempting to fund new LN channel.");
+            Self::fund_channel(&mut rpc_gateway, &rpc_other, bitcoin);
+        }
+        let initial_balance = Self::channel_balance(&rpc_gateway);
+        let gateway_pubkey =
+            secp256k1::PublicKey::from_str(&rpc_gateway.getinfo().unwrap().id).unwrap();
+
+        RealLightningTest {
+            rpc_gateway,
+            rpc_other,
+            initial_balance,
+            gateway_node_pub_key: gateway_pubkey,
+        }
+    }
+}
+
+impl RealLightningTest {
+    fn fund_channel(
+        rpc_gateway: &mut LightningRPC,
+        rpc_other: &LightningRPC,
+        bitcoin: &dyn BitcoinTest,
+    ) {
+        const FUND_AMOUNT: u64 = 10 * 1000 * 1000;
+
+        let info = rpc_other.getinfo().unwrap();
+        let other_ip = match info.binding.first().unwrap() {
+            NetworkAddress::Ipv4 { address, port } => format!("{}:{}", address, port),
+            address => panic!("Non ipv4 address {:?}", address),
+        };
+        rpc_gateway.connect(&info.id, Some(&other_ip)).unwrap();
+
+        let funding_address = rpc_gateway.newaddr(None).unwrap().bech32.unwrap();
+        bitcoin.send_and_mine_block(
+            &Address::from_str(&funding_address).unwrap(),
+            bitcoin::Amount::from_sat(FUND_AMOUNT * 2),
+        );
+        bitcoin.mine_blocks(10);
+
+        loop {
+            let fund_channel = FundChannelFixed {
+                id: &info.id,
+                amount: FUND_AMOUNT,
+            };
+            let response = rpc_gateway
+                .client()
+                .send_request::<FundChannelFixed, responses::FundChannel>(
+                    "fundchannel",
+                    fund_channel,
+                )
+                .expect("Error requesting funds.")
+                .into_result();
+            match response {
+                Ok(_) => break,
+                Err(clightningrpc::Error::Rpc(e)) if e.code == 304 || e.code == 301 => {
+                    warn!("LN awaiting block sync, please wait...")
+                }
+                Err(err) => panic!("Unexpected error {}", err),
+            }
+            thread::sleep(Duration::from_millis(1000));
+        }
+        bitcoin.mine_blocks(10);
+
+        loop {
+            warn!("LN channel not open yet, please wait...");
+            if Self::channel_balance(&rpc_gateway) == Amount::from_sat(FUND_AMOUNT) {
+                break;
+            }
+            thread::sleep(Duration::from_millis(1000));
+        }
+    }
+
+    fn channel_balance(rpc: &LightningRPC) -> Amount {
+        let funds: u64 = rpc
+            .listfunds()
+            .unwrap()
+            .channels
+            .iter()
+            .filter(|channel| channel.short_channel_id.is_some() && channel.connected)
+            .map(|channel| channel.our_amount_msat.0)
+            .sum();
+        Amount::from_msat(funds)
+    }
+}
+
+// FIXME workaround for bad RPC API, should replace when cln_rpc gets updated
+#[derive(Debug, Clone, Serialize)]
+struct FundChannelFixed<'a> {
+    pub id: &'a str,
+    pub amount: u64,
+}
+
+pub struct RealBitcoinTest {
+    client: Client,
+}
+
+impl RealBitcoinTest {
+    const ERROR: &'static str = "Bitcoin RPC returned an error";
+
+    pub fn new(wallet_config: WalletConfig) -> Self {
+        let client = Client::new(
+            &(wallet_config.btc_rpc_address),
+            Auth::UserPass(
+                wallet_config.btc_rpc_user.clone(),
+                wallet_config.btc_rpc_pass.clone(),
+            ),
+        )
+        .expect(Self::ERROR);
+
+        // ensure we have a wallet with bitcoin
+        if client.list_wallets().expect(Self::ERROR).len() == 0 {
+            client
+                .create_wallet("", None, None, None, None)
+                .expect(Self::ERROR);
+        }
+
+        if client
+            .get_balances()
+            .expect(Self::ERROR)
+            .mine
+            .trusted
+            .as_btc()
+            < 100.0
+        {
+            let address = client.get_new_address(None, None).expect(Self::ERROR);
+            client
+                .generate_to_address(200, &address)
+                .expect(Self::ERROR);
+        }
+
+        Self { client }
+    }
+}
+
+impl BitcoinTest for RealBitcoinTest {
+    fn mine_blocks(&self, block_num: u64) {
+        self.client
+            .generate_to_address(block_num, &self.get_new_address())
+            .expect(Self::ERROR);
+    }
+
+    fn send_and_mine_block(
+        &self,
+        address: &Address,
+        amount: bitcoin::Amount,
+    ) -> (TxOutProof, Transaction) {
+        let id = self
+            .client
+            .send_to_address(address, amount, None, None, None, None, None, None)
+            .expect(Self::ERROR);
+        self.mine_blocks(1);
+
+        let tx = self
+            .client
+            .get_raw_transaction(&id, None)
+            .expect(Self::ERROR);
+        let proof = TxOutProof::consensus_decode(Cursor::new(
+            self.client
+                .get_tx_out_proof(&[id], None)
+                .expect(Self::ERROR),
+        ))
+        .expect(Self::ERROR);
+
+        return (proof, tx);
+    }
+
+    fn get_new_address(&self) -> Address {
+        self.client.get_new_address(None, None).expect(Self::ERROR)
+    }
+
+    fn mine_block_and_get_received(&self, address: &Address) -> Amount {
+        self.mine_blocks(1);
+        self.client
+            .get_received_by_address(address, None)
+            .expect(Self::ERROR)
+            .into()
+    }
+}

--- a/minimint/tests/integrationtest.rs
+++ b/minimint/tests/integrationtest.rs
@@ -1,0 +1,211 @@
+use assert_matches::assert_matches;
+use bitcoin::Amount;
+use fixture::fixtures;
+use fixture::{rng, sats};
+use minimint::consensus::ConsensusItem;
+use minimint_wallet::WalletConsensusItem::PegOutSignature;
+use std::ops::Sub;
+
+mod fixture;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn peg_in_and_peg_out_with_fees() {
+    let (fed, user, bitcoin, _, _) = fixtures(2, 0, &[sats(100), sats(1000)]).await;
+    let peg_in_address = user.client.get_new_pegin_address(rng());
+
+    let (proof, tx) = bitcoin.send_and_mine_block(&peg_in_address, Amount::from_sat(5000));
+    bitcoin.mine_blocks(fed.wallet.finalty_delay as u64);
+    fed.run_consensus_epochs(2).await;
+
+    user.client.peg_in(proof, tx, rng()).await.unwrap();
+    fed.run_consensus_epochs(4).await; // peg in epoch + partial sigs epoch
+
+    user.client.fetch_all_coins().await.unwrap();
+    assert_eq!(
+        user.total_coins(),
+        sats(5000).sub(fed.fee_consensus.fee_peg_in_abs)
+    );
+    let peg_out_address = bitcoin.get_new_address();
+    user.client
+        .peg_out(Amount::from_sat(1000), peg_out_address.clone(), rng())
+        .await
+        .unwrap();
+    fed.run_consensus_epochs(2).await;
+
+    bitcoin.mine_blocks(minimint_wallet::MIN_PEG_OUT_URGENCY as u64 + 1);
+    fed.run_consensus_epochs(5).await; // block height epoch + 2 peg out signing epochs
+    assert_matches!(
+        fed.last_consensus().first(),
+        Some(ConsensusItem::Wallet(PegOutSignature(_)))
+    );
+
+    fed.broadcast_transactions().await;
+    assert_eq!(
+        bitcoin.mine_block_and_get_received(&peg_out_address),
+        sats(1000)
+    );
+    assert_eq!(
+        user.total_coins(),
+        sats(4000)
+            .sub(fed.fee_consensus.fee_peg_in_abs)
+            .sub(fed.fee_consensus.fee_peg_out_abs)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn peg_out_with_p2pkh() {
+    // FIXME Hash of peg-out transaction doesn't match in wallet and fed code, causing InvalidSignature error
+    let (fed, user, _, _, _) = fixtures(2, 0, &[sats(100), sats(1000)]).await;
+    fed.mint_coins_for_user(&user, sats(4500)).await;
+
+    let ctx = bitcoin::secp256k1::Secp256k1::new();
+    let (_, public_key) = ctx.generate_keypair(&mut rng());
+    let peg_out_address = bitcoin::Address::p2pkh(
+        &bitcoin::ecdsa::PublicKey::new(public_key),
+        bitcoin::Network::Regtest,
+    );
+    user.client
+        .peg_out(Amount::from_sat(1000), peg_out_address.clone(), rng())
+        .await
+        .unwrap();
+    fed.run_consensus_epochs(2).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn minted_coins_can_be_exchanged_between_users() {
+    let (fed, user_send, _, _, _) = fixtures(2, 0, &[sats(100), sats(1000)]).await;
+    let user_receive = user_send.new_client(&[0]);
+
+    fed.mint_coins_for_user(&user_send, sats(5000)).await;
+    assert_eq!(user_send.total_coins(), sats(5000));
+    assert_eq!(user_receive.total_coins(), sats(0));
+
+    let coins = user_send.client.select_and_spend_coins(sats(3000)).unwrap();
+    let outpoint = user_receive.client.reissue(coins, rng()).await.unwrap();
+    fed.run_consensus_epochs(4).await; // process transaction + sign new coins
+
+    user_receive.client.fetch_coins(outpoint).await.unwrap();
+    assert_eq!(user_send.total_coins(), sats(2000));
+    assert_eq!(user_receive.total_coins(), sats(3000));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn minted_coins_cannot_double_spent_with_different_nodes() {
+    let (fed, user1, _, _, _) = fixtures(2, 0, &[sats(100), sats(1000)]).await;
+    fed.mint_coins_for_user(&user1, sats(5000)).await;
+    let coins = user1.client.select_and_spend_coins(sats(2000)).unwrap();
+
+    let (user2, user3) = (user1.new_client(&[0]), user1.new_client(&[1]));
+    let out2 = user2.client.reissue(coins.clone(), rng()).await.unwrap();
+    let out3 = user3.client.reissue(coins, rng()).await.unwrap();
+    fed.run_consensus_epochs(4).await; // process transaction + sign new coins
+
+    // FIXME is this the correct behavior, that the first one goes through?
+    assert!(user2.client.fetch_coins(out2).await.is_ok());
+    assert!(user3.client.fetch_coins(out3).await.is_err());
+    assert_eq!(user2.total_coins(), sats(2000));
+    assert_eq!(user3.total_coins(), sats(0));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+// FIXME should be able to fetch change coins fails with NotEnoughCoins
+// https://github.com/fedimint/minimint/issues/11
+async fn minted_coins_in_wallet_can_be_split_into_change() {
+    let (fed, user, _, _, _) = fixtures(2, 0, &[sats(100), sats(1000)]).await;
+    fed.mint_coins_for_user(&user, sats(2100)).await;
+    assert_eq!(user.coin_amounts(), vec![sats(100), sats(1000), sats(1000)]);
+
+    user.client.select_and_spend_coins(sats(1900)).unwrap();
+    fed.run_consensus_epochs(4).await; // process transaction + sign new coins
+    assert_eq!(user.coin_amounts(), vec![sats(100), sats(100)]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn minted_coins_can_be_created_with_different_max_evil_thresholds() {
+    // FIXME Fails because of InvalidSignature error
+    let (fed, user, _, _, _) = fixtures(5, 0, &[sats(100), sats(1000)]).await;
+    fed.mint_coins_for_user(&user, sats(1000)).await;
+    assert_eq!(user.total_coins(), sats(1000));
+
+    // FIXME Fails because HBBFT consensus hangs without all nodes
+    let (fed, user, _, _, _) = fixtures(3, 1, &[sats(100), sats(1000)]).await;
+    fed.subset_peers(&[0, 1])
+        .mint_coins_for_user(&user, sats(2000))
+        .await;
+    assert_eq!(user.total_coins(), sats(2000));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lightning_gateway_pays_invoice() {
+    let (fed, user, _, gateway, lightning) = fixtures(2, 0, &[sats(10), sats(1000)]).await;
+    let invoice = lightning.invoice(sats(1000));
+
+    fed.mint_coins_for_user(&user, sats(1010)).await; // 1% LN fee
+    let contract_id = user
+        .client
+        .fund_outgoing_ln_contract(&gateway.keys, invoice, rng())
+        .await
+        .unwrap();
+    fed.run_consensus_epochs(2).await; // send coins to LN contract
+
+    let contract_account = user.client.wait_contract(contract_id).await.unwrap();
+    assert_eq!(contract_account.amount, sats(1010));
+    gateway
+        .server
+        .pay_invoice(contract_id, rng())
+        .await
+        .unwrap();
+    fed.run_consensus_epochs(4).await; // contract to mint coins, sign coins
+
+    gateway.server.await_contract_claimed(contract_id).await;
+    assert_eq!(user.total_coins(), sats(0));
+    assert_eq!(gateway.user_client.coins().amount(), sats(1010));
+    assert_eq!(lightning.amount_sent(), sats(1000));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lightning_gateway_cannot_claim_invalid_preimage() {
+    let (fed, user, _, gateway, lightning) = fixtures(2, 0, &[sats(10), sats(1000)]).await;
+    let invoice = lightning.invoice(sats(1000));
+
+    fed.mint_coins_for_user(&user, sats(1010)).await; // 1% LN fee
+    let contract_id = user
+        .client
+        .fund_outgoing_ln_contract(&gateway.keys, invoice, rng())
+        .await
+        .unwrap();
+    fed.run_consensus_epochs(2).await; // send coins to LN contract
+
+    let bad_preimage: [u8; 32] = rand::random();
+    let response = gateway
+        .client
+        .claim_outgoing_contract(contract_id, bad_preimage, rng())
+        .await;
+    assert!(response.is_err());
+
+    fed.run_consensus_epochs(2).await; // if valid would create contract to mint coins
+    assert!(fed.last_consensus().is_empty())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn lightning_gateway_can_abort_payment_to_return_user_funds() {
+    let (fed, user, _, gateway, lightning) = fixtures(2, 0, &[sats(10), sats(1000)]).await;
+    let invoice = lightning.invoice(sats(1000));
+
+    fed.mint_coins_for_user(&user, sats(1010)).await; // 1% LN fee
+    let contract_id = user
+        .client
+        .fund_outgoing_ln_contract(&gateway.keys, invoice, rng())
+        .await
+        .unwrap();
+    fed.run_consensus_epochs(2).await; // send coins to LN contract
+
+    // FIXME should return funds to user
+    gateway.client.abort_outgoing_payment(contract_id);
+    fed.run_consensus_epochs(2).await;
+    assert_eq!(user.total_coins(), sats(1010));
+}

--- a/mint-client/src/clients/user.rs
+++ b/mint-client/src/clients/user.rs
@@ -66,7 +66,7 @@ impl UserClient {
         }
     }
 
-    fn mint_client(&self) -> MintClient {
+    pub fn mint_client(&self) -> MintClient {
         MintClient {
             context: self.context.borrow_with_module_config(|cfg| &cfg.mint),
         }

--- a/mint-client/src/lib.rs
+++ b/mint-client/src/lib.rs
@@ -1,4 +1,4 @@
-mod api;
+pub mod api;
 pub mod clients;
 pub mod ln;
 pub mod mint;

--- a/modules/minimint-mint/src/lib.rs
+++ b/modules/minimint-mint/src/lib.rs
@@ -46,8 +46,8 @@ pub struct Mint {
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct PartiallySignedRequest {
-    out_point: OutPoint,
-    partial_signature: PartialSigResponse,
+    pub out_point: OutPoint,
+    pub partial_signature: PartialSigResponse,
 }
 
 /// Request to blind sign a certain amount of coins

--- a/modules/minimint-wallet/src/txoproof.rs
+++ b/modules/minimint-wallet/src/txoproof.rs
@@ -28,8 +28,8 @@ pub struct PegInProof {
 
 #[derive(Clone, Debug)]
 pub struct TxOutProof {
-    block_header: BlockHeader,
-    merkle_proof: PartialMerkleTree,
+    pub block_header: BlockHeader,
+    pub merkle_proof: PartialMerkleTree,
 }
 
 impl TxOutProof {

--- a/scripts/final-checks.sh
+++ b/scripts/final-checks.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Checks to run before opening a PR, should be run from minimint source root dir
+# See minimint/tests/TESTING.md for information on setting up Bitcoin / Lightning so the integration tests can complete
+
+set -e
+
+cargo clippy --workspace -- -D warnings
+cargo fmt --all -- --check
+
+export MINIMINT_TEST_REAL=0
+cargo test
+
+export MINIMINT_TEST_REAL=1
+export MINIMINT_TEST_DIR=$PWD/it/
+cargo test -p minimint -- --test-threads=1

--- a/scripts/integrationtest.sh
+++ b/scripts/integrationtest.sh
@@ -53,13 +53,17 @@ done
 LN1="lightning-cli --network regtest --lightning-dir=$LN1_DIR"
 LN2="lightning-cli --network regtest --lightning-dir=$LN2_DIR"
 
+# Run the Rust integration tests against the real Bitcoin / Lightning services
+export MINIMINT_TEST_REAL=1
+export MINIMINT_TEST_DIR=$TMP_DIR
+cargo test -p minimint -- --test-threads=1
+
 # Generate federation, gateway and client config
 $BIN_DIR/configgen -- $CFG_DIR 4 4000 5000 1000 10000 100000 1000000 10000000
 LN1_PUB_KEY="$($LN1 getinfo | jq -r '.id')"
 $BIN_DIR/gw_configgen -- $CFG_DIR "$LN1_DIR/regtest/lightning-rpc" $LN1_PUB_KEY
 
 # Initialize wallet and get ourselves some money
-$BTC_CLIENT createwallet main
 function mine_blocks() {
     PEG_IN_ADDR="$($BTC_CLIENT getnewaddress)"
     $BTC_CLIENT generatetoaddress $1 $PEG_IN_ADDR


### PR DESCRIPTION
I have added the ability to integration test in Rust, and written 5 passing integration tests and 4 failing (ignored) that identify known or possibly new issues.

The tests can run with fake or real versions of Bitcoin/LN, when running in parallel all tests run in <10sec.

I minimized any changes to production code, but had to refactor some infinite loops.  No changes to existing functionality should occur.

The new test fixtures allow developers to manipulate/inspect consensus, Bitcoin, LN, and test via the gateway/user client APIs.

Side-note: I'm not a fan of what `cargo fmt` does to legibility so I've separated the PR into two separate commits.  Also added a convenient script to run all checks before opening a PR.

More documentation can be found here: https://github.com/jkitman/minimint/blob/rust-integration-tests/minimint/tests/TESTING.md