### PR TITLE
Migrate from structopt to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,17 +613,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2 1.0.39",
+ "quote 1.0.18",
+ "syn 1.0.95",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1285,6 +1309,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +1618,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "async-trait",
+ "clap",
  "cln-rpc",
  "futures",
  "hex",
@@ -1600,7 +1631,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sled",
- "structopt",
  "thiserror",
  "tide",
  "tokio",
@@ -1692,6 +1722,7 @@ dependencies = [
  "bincode",
  "bitcoin",
  "bitcoincore-rpc",
+ "clap",
  "clightningrpc",
  "cln-rpc",
  "futures",
@@ -1714,7 +1745,6 @@ dependencies = [
  "serde_json",
  "sha3",
  "sled",
- "structopt",
  "tbs",
  "thiserror",
  "tide",
@@ -1752,7 +1782,7 @@ dependencies = [
 name = "minimint-derive"
 version = "0.1.0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2 1.0.39",
  "quote 1.0.18",
  "syn 1.0.95",
@@ -1852,6 +1882,7 @@ dependencies = [
  "bincode",
  "bitcoin",
  "bitcoin_hashes",
+ "clap",
  "futures",
  "hex",
  "lightning",
@@ -1865,7 +1896,6 @@ dependencies = [
  "serde",
  "sha3",
  "sled",
- "structopt",
  "tbs",
  "test-log",
  "thiserror",
@@ -2008,6 +2038,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "pairing"
@@ -2951,33 +2987,9 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -3060,6 +3072,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "bls12_381",
+ "clap",
  "ff",
  "group",
  "hex",
@@ -3067,7 +3080,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "sha3",
- "structopt",
 ]
 
 [[package]]
@@ -3116,12 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -3436,12 +3445,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3546,12 +3549,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/crypto/tbs/Cargo.toml
+++ b/crypto/tbs/Cargo.toml
@@ -17,5 +17,5 @@ serde = { version = "1.0", features = ["derive"] }
 sha3 = "0.9.1"
 
 [dev-dependencies]
-structopt = "0.3.21"
 bincode = "1.3.1"
+clap = { version = "3.1.18", features = ["derive"] }

--- a/crypto/tbs/examples/keygen.rs
+++ b/crypto/tbs/examples/keygen.rs
@@ -1,15 +1,15 @@
+use clap::Parser;
 use serde::Serialize;
-use structopt::StructOpt;
 use tbs::dealer_keygen;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
     number: usize,
     threshold: usize,
 }
 
 fn main() {
-    let args: Args = StructOpt::from_args();
+    let args = Args::parse();
 
     let (pk, pks, sks) = dealer_keygen(args.threshold, args.number);
 

--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 async-std = { version = "1.6.0", features = ["attributes", "tokio1"] }
 async-trait = "0.1.52"
 cln-rpc = "0.1"
+clap = { version = "3.1.18", features = ["derive"] }
 futures = "0.3.21"
 hex = "0.4.3"
 lightning-invoice = "0.14.0"
@@ -20,7 +21,6 @@ secp256k1 = "0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.61"
 sled = "0.34.6"
-structopt = "0.3.21"
 thiserror = "1.0.30"
 tide = "0.16.0"
 tracing = "0.1.26"

--- a/ln-gateway/src/bin/gw_configgen.rs
+++ b/ln-gateway/src/bin/gw_configgen.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use ln_gateway::LnGatewayConfig;
 use minimint::config::load_from_file;
 use mint_client::clients::gateway::GatewayClientConfig;
@@ -6,9 +7,8 @@ use mint_client::ClientAndGatewayConfig;
 use rand::thread_rng;
 use secp256k1::PublicKey;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Opts {
     workdir: PathBuf,
     ln_rpc_path: PathBuf,
@@ -16,7 +16,7 @@ struct Opts {
 }
 
 fn main() {
-    let opts: Opts = StructOpt::from_args();
+    let opts = Opts::parse();
     let federation_client_cfg_path = opts.workdir.join("federation_client.json");
     let federation_client_cfg: minimint::config::ClientConfig =
         load_from_file(&federation_client_cfg_path);

--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -1,9 +1,9 @@
+use clap::Parser;
 use ln_gateway::{LnGateway, LnGatewayConfig};
 use minimint::config::load_from_file;
 use minimint::modules::ln::contracts::ContractId;
 use std::path::PathBuf;
 use std::sync::Arc;
-use structopt::StructOpt;
 use tide::Response;
 use tracing::{debug, instrument};
 use tracing_subscriber::EnvFilter;
@@ -13,7 +13,7 @@ pub struct State {
     gateway: Arc<LnGateway>,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Opts {
     workdir: PathBuf,
 }
@@ -43,7 +43,7 @@ async fn main() -> tide::Result<()> {
         )
         .init();
 
-    let opts: Opts = StructOpt::from_args();
+    let opts = Opts::parse();
     let cfg_path = opts.workdir.join("gateway.json");
     let db_path = opts.workdir.join("gateway.db");
     let cfg: LnGatewayConfig = load_from_file(&cfg_path);

--- a/minimint-api/src/encoding/mod.rs
+++ b/minimint-api/src/encoding/mod.rs
@@ -27,7 +27,7 @@ pub trait Decodable: Sized {
 }
 
 #[derive(Debug, Error)]
-pub struct DecodeError(pub(crate) Box<dyn std::error::Error + Send>);
+pub struct DecodeError(pub(crate) Box<dyn std::error::Error + Send + Sync>);
 
 macro_rules! impl_encode_decode_num {
     ($num_type:ty) => {
@@ -233,7 +233,7 @@ impl DecodeError {
         DecodeError(Box::new(StrError(s)))
     }
 
-    pub fn from_err<E: std::error::Error + Send + 'static>(e: E) -> Self {
+    pub fn from_err<E: std::error::Error + Send + Sync + 'static>(e: E) -> Self {
         DecodeError(Box::new(e))
     }
 }

--- a/minimint/Cargo.toml
+++ b/minimint/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 async-trait = "0.1.42"
 bincode = "1.3.1"
 bitcoin = "0.27.0"
+clap = { version = "3.1.18", features = ["derive"] }
 futures = "0.3.9"
 hbbft = { git = "https://github.com/fedimint/hbbft", branch = "minimint" }
 hex = "0.4.2"
@@ -26,7 +27,6 @@ serde = { version = "1.0.118", features = [ "derive" ] }
 serde_json = "1.0.61"
 sha3 = "0.9.1"
 sled = "0.34.6"
-structopt = "0.3.21"
 tbs = { path = "../crypto/tbs" }
 thiserror = "1.0.23"
 tide = "0.16.0"

--- a/minimint/src/bin/configgen.rs
+++ b/minimint/src/bin/configgen.rs
@@ -1,11 +1,11 @@
+use clap::Parser;
 use minimint::config::{ServerConfig, ServerConfigParams};
 use minimint_api::config::GenerateConfig;
 use minimint_api::{Amount, PeerId};
 use rand::rngs::OsRng;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Options {
     cfg_path: PathBuf,
     nodes: u16,
@@ -21,7 +21,7 @@ fn main() {
         hbbft_base_port,
         api_base_port,
         amount_tiers,
-    } = StructOpt::from_args();
+    } = Options::parse();
     let mut rng = OsRng::new().unwrap();
 
     // Recursively create config directory if it doesn't exist

--- a/minimint/src/bin/server.rs
+++ b/minimint/src/bin/server.rs
@@ -1,6 +1,6 @@
+use clap::Parser;
 use minimint::config::{load_from_file, ServerConfig, ServerOpts};
 use minimint::run_minimint;
-use structopt::StructOpt;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -11,7 +11,7 @@ async fn main() {
         )
         .init();
 
-    let opts: ServerOpts = StructOpt::from_args();
+    let opts = ServerOpts::parse();
     let cfg: ServerConfig = load_from_file(&opts.cfg_path);
 
     run_minimint(cfg).await;

--- a/minimint/src/config.rs
+++ b/minimint/src/config.rs
@@ -1,4 +1,5 @@
 use bitcoin::secp256k1::rand::{CryptoRng, RngCore};
+use clap::Parser;
 use hbbft::crypto::serde_impl::SerdeSecret;
 use minimint_api::config::GenerateConfig;
 use minimint_api::PeerId;
@@ -10,9 +11,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct ServerOpts {
     pub cfg_path: PathBuf,
 }

--- a/mint-client/Cargo.toml
+++ b/mint-client/Cargo.toml
@@ -12,6 +12,7 @@ base64 = "0.13.0"
 bincode = "1.3.1"
 bitcoin = "0.27.0"
 bitcoin_hashes = "0.10.0"
+clap = { version = "3.1.18", features = ["derive"] }
 futures = "0.3.9"
 hex = "0.4.3"
 lightning-invoice = "0.14.0"
@@ -25,7 +26,6 @@ secp256k1-zkp = { git = "https://github.com/fedimint/rust-secp256k1-zkp", branch
 serde = { version = "1.0.118", features = [ "derive" ] }
 sha3 = "0.9.1"
 sled = "0.34.6"
-structopt = "0.3.21"
 tbs = { path = "../crypto/tbs" }
 thiserror = "1.0.23"
 tokio = { version = "1.0.1", features = ["full"] }


### PR DESCRIPTION
> As clap v3 is now out, and the structopt features are integrated into (almost as-is).
> structopt is now in maintenance mode: no new feature will be added.
> Bugs will be fixed, and documentation improvements will be accepted.

NOTE: clap also require `Sync` for error of `try_from_str`