### PR TITLE
Update architecture doc

### DIFF
--- a/minimint/src/consensus/interconnect.rs
+++ b/minimint/src/consensus/interconnect.rs
@@ -1,4 +1,4 @@
-use crate::consensus::FediMintConsensus;
+use crate::consensus::MinimintConsensus;
 use minimint_api::module::http;
 use minimint_api::module::http::{Method, Response};
 use minimint_api::module::interconnect::ModuleInterconect;
@@ -7,11 +7,11 @@ use rand::CryptoRng;
 use secp256k1_zkp::rand::RngCore;
 use serde_json::Value;
 
-pub struct FediMintInterconnect<'a, R: RngCore + CryptoRng> {
-    pub fedimint: &'a FediMintConsensus<R>,
+pub struct MinimintInterconnect<'a, R: RngCore + CryptoRng> {
+    pub minimint: &'a MinimintConsensus<R>,
 }
 
-impl<'a, R> ModuleInterconect for FediMintInterconnect<'a, R>
+impl<'a, R> ModuleInterconect for MinimintInterconnect<'a, R>
 where
     R: RngCore + CryptoRng,
 {
@@ -23,9 +23,9 @@ where
         data: Value,
     ) -> http::Result<Response> {
         match module {
-            "wallet" => call_internal(&self.fedimint.wallet, path, method, data),
-            "mint" => call_internal(&self.fedimint.mint, path, method, data),
-            "ln" => call_internal(&self.fedimint.ln, path, method, data),
+            "wallet" => call_internal(&self.minimint.wallet, path, method, data),
+            "mint" => call_internal(&self.minimint.mint, path, method, data),
+            "ln" => call_internal(&self.minimint.ln, path, method, data),
             _ => Err(http::Error::from_str(404, "Module not found")),
         }
     }

--- a/minimint/src/consensus/mod.rs
+++ b/minimint/src/consensus/mod.rs
@@ -5,7 +5,7 @@ mod interconnect;
 
 use crate::config::ServerConfig;
 use crate::consensus::conflictfilter::ConflictFilterable;
-use crate::consensus::interconnect::FediMintInterconnect;
+use crate::consensus::interconnect::MinimintInterconnect;
 use crate::db::{AcceptedTransactionKey, ProposedTransactionKey, ProposedTransactionKeyPrefix};
 use crate::outcome::OutputOutcome;
 use crate::rng::RngGenerator;
@@ -36,7 +36,7 @@ pub enum ConsensusItem {
 pub type HoneyBadgerMessage = hbbft::honey_badger::Message<PeerId>;
 pub type ConsensusOutcome = Batch<Vec<ConsensusItem>, PeerId>;
 
-pub struct FediMintConsensus<R>
+pub struct MinimintConsensus<R>
 where
     R: RngCore + CryptoRng,
 {
@@ -67,7 +67,7 @@ struct VerificationCaches {
     ln: <LightningModule as FederationModule>::VerificationCache,
 }
 
-impl<R> FediMintConsensus<R>
+impl<R> MinimintConsensus<R>
 where
     R: RngCore + CryptoRng,
 {
@@ -423,25 +423,25 @@ where
         }
     }
 
-    fn build_interconnect(&self) -> FediMintInterconnect<R> {
-        FediMintInterconnect { fedimint: self }
+    fn build_interconnect(&self) -> MinimintInterconnect<R> {
+        MinimintInterconnect { minimint: self }
     }
 }
 
-impl<'a, R: RngCore + CryptoRng> From<&'a FediMintConsensus<R>> for &'a Wallet {
-    fn from(fed: &'a FediMintConsensus<R>) -> Self {
+impl<'a, R: RngCore + CryptoRng> From<&'a MinimintConsensus<R>> for &'a Wallet {
+    fn from(fed: &'a MinimintConsensus<R>) -> Self {
         &fed.wallet
     }
 }
 
-impl<'a, R: RngCore + CryptoRng> From<&'a FediMintConsensus<R>> for &'a Mint {
-    fn from(fed: &'a FediMintConsensus<R>) -> Self {
+impl<'a, R: RngCore + CryptoRng> From<&'a MinimintConsensus<R>> for &'a Mint {
+    fn from(fed: &'a MinimintConsensus<R>) -> Self {
         &fed.mint
     }
 }
 
-impl<'a, R: RngCore + CryptoRng> From<&'a FediMintConsensus<R>> for &'a LightningModule {
-    fn from(fed: &'a FediMintConsensus<R>) -> Self {
+impl<'a, R: RngCore + CryptoRng> From<&'a MinimintConsensus<R>> for &'a LightningModule {
+    fn from(fed: &'a MinimintConsensus<R>) -> Self {
         &fed.ln
     }
 }

--- a/minimint/src/lib.rs
+++ b/minimint/src/lib.rs
@@ -19,7 +19,7 @@ use minimint_ln::LightningModule;
 use minimint_wallet::bitcoind::BitcoindRpc;
 use minimint_wallet::Wallet;
 
-use crate::consensus::{ConsensusItem, FediMintConsensus};
+use crate::consensus::{ConsensusItem, MinimintConsensus};
 use crate::net::connect::Connections;
 use crate::net::PeerConnections;
 use crate::rng::RngGenerator;
@@ -52,7 +52,7 @@ pub struct MinimintServer {
     pub proposal_receiver: Receiver<Vec<ConsensusItem>>,
     pub outcome_receiver: Receiver<ConsensusOutcome>,
     pub proposal_sender: Sender<Vec<ConsensusItem>>,
-    pub mint_consensus: Arc<FediMintConsensus<OsRng>>,
+    pub mint_consensus: Arc<MinimintConsensus<OsRng>>,
     pub cfg: ServerConfig,
 }
 
@@ -109,7 +109,7 @@ pub async fn minimint_server_with(
 
     let ln = LightningModule::new(cfg.ln.clone(), database.clone());
 
-    let mint_consensus = Arc::new(FediMintConsensus {
+    let mint_consensus = Arc::new(MinimintConsensus {
         rng_gen: Box::new(CloneRngGen(Mutex::new(OsRng::new().unwrap()))), //FIXME
         cfg: cfg.clone(),
         mint,
@@ -132,7 +132,7 @@ pub async fn minimint_server_with(
 }
 
 pub async fn run_consensus(
-    mint_consensus: &Arc<FediMintConsensus<OsRng>>,
+    mint_consensus: &Arc<MinimintConsensus<OsRng>>,
     mut outcome_receiver: Receiver<ConsensusOutcome>,
     proposal_sender: Sender<Vec<ConsensusItem>>,
     cfg: ServerConfig,
@@ -152,7 +152,7 @@ pub async fn run_consensus(
 }
 
 pub async fn run_consensus_epoch(
-    mint_consensus: &Arc<FediMintConsensus<OsRng>>,
+    mint_consensus: &Arc<MinimintConsensus<OsRng>>,
     outcome: ConsensusOutcome,
     proposal_sender: &Sender<Vec<ConsensusItem>>,
     cfg: &ServerConfig,

--- a/minimint/tests/fixture/mod.rs
+++ b/minimint/tests/fixture/mod.rs
@@ -27,7 +27,7 @@ use ln_gateway::ln::LnRpc;
 use ln_gateway::LnGateway;
 use minimint::config::ServerConfigParams;
 use minimint::config::{ClientConfig, FeeConsensus, ServerConfig};
-use minimint::consensus::{ConsensusItem, ConsensusOutcome, FediMintConsensus};
+use minimint::consensus::{ConsensusItem, ConsensusOutcome, MinimintConsensus};
 use minimint::transaction::{Input, Output};
 use minimint::MinimintServer;
 use minimint_api::config::GenerateConfig;
@@ -291,7 +291,7 @@ pub struct FederationTest {
 struct ServerTest {
     outcome_receiver: Receiver<ConsensusOutcome>,
     proposal_sender: Sender<Vec<ConsensusItem>>,
-    consensus: Arc<FediMintConsensus<OsRng>>,
+    consensus: Arc<MinimintConsensus<OsRng>>,
     cfg: ServerConfig,
     bitcoin_rpc: Box<dyn BitcoindRpc>,
     database: Arc<dyn Database>,


### PR DESCRIPTION
This PR renames `FediMint` to `Minimint` (less confusing) and updates the `architecture.md` doc to better reflect the codebase to help new developers.