### PR TITLE
Coin selection

### DIFF
--- a/minimint/src/transaction.rs
+++ b/minimint/src/transaction.rs
@@ -82,19 +82,22 @@ impl TransactionItem for Output {
 }
 
 impl Transaction {
-    pub fn validate_funding(&self, fee_consensus: &FeeConsensus) -> Result<(), TransactionError> {
-        let in_amount = self
-            .inputs
+    pub fn in_amount(&self) -> Amount {
+        self.inputs
             .iter()
             .map(TransactionItem::amount)
-            .sum::<Amount>();
-        let out_amount = self
-            .outputs
+            .sum::<Amount>()
+    }
+
+    pub fn out_amount(&self) -> Amount {
+        self.outputs
             .iter()
             .map(TransactionItem::amount)
-            .sum::<Amount>();
-        let fee_amount = self
-            .inputs
+            .sum::<Amount>()
+    }
+
+    pub fn fee_amount(&self, fee_consensus: &FeeConsensus) -> Amount {
+        self.inputs
             .iter()
             .map(|input| input.fee(fee_consensus))
             .sum::<Amount>()
@@ -102,7 +105,13 @@ impl Transaction {
                 .outputs
                 .iter()
                 .map(|output| output.fee(fee_consensus))
-                .sum::<Amount>();
+                .sum::<Amount>()
+    }
+
+    pub fn validate_funding(&self, fee_consensus: &FeeConsensus) -> Result<(), TransactionError> {
+        let in_amount = self.in_amount();
+        let out_amount = self.out_amount();
+        let fee_amount = self.fee_amount(fee_consensus);
 
         if in_amount >= (out_amount + fee_amount) {
             Ok(())

--- a/mint-client/src/clients/mod.rs
+++ b/mint-client/src/clients/mod.rs
@@ -1,2 +1,3 @@
 pub mod gateway;
+pub mod transaction;
 pub mod user;

--- a/mint-client/src/clients/transaction.rs
+++ b/mint-client/src/clients/transaction.rs
@@ -1,0 +1,57 @@
+use rand::{CryptoRng, RngCore};
+use secp256k1_zkp::schnorrsig;
+
+use minimint::config::FeeConsensus;
+use minimint::transaction::{Input, Output, Transaction};
+use minimint_api::Amount;
+
+pub struct TransactionBuilder {
+    keys: Vec<schnorrsig::KeyPair>,
+    pub tx: Transaction,
+}
+
+impl Default for TransactionBuilder {
+    fn default() -> Self {
+        TransactionBuilder {
+            keys: vec![],
+            tx: Transaction {
+                inputs: vec![],
+                outputs: vec![],
+                signature: None,
+            },
+        }
+    }
+}
+
+impl TransactionBuilder {
+    pub fn input(&mut self, key: &mut Vec<schnorrsig::KeyPair>, input: Input) {
+        self.keys.append(key);
+        self.tx.inputs.push(input);
+    }
+
+    pub fn output(&mut self, output: Output) {
+        self.tx.outputs.push(output);
+    }
+
+    pub fn change_required(&self, fees: &FeeConsensus) -> Amount {
+        self.tx.in_amount() - self.tx.out_amount() - self.tx.fee_amount(fees)
+    }
+
+    pub fn build<R: RngCore + CryptoRng>(
+        mut self,
+        secp: &secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
+        mut rng: R,
+    ) -> Transaction {
+        if !self.keys.is_empty() {
+            let signature = minimint::transaction::agg_sign(
+                &self.keys,
+                self.tx.tx_hash().as_hash(),
+                secp,
+                &mut rng,
+            );
+            self.tx.signature = Some(signature);
+        }
+
+        self.tx
+    }
+}

--- a/mint-client/src/clients/user.rs
+++ b/mint-client/src/clients/user.rs
@@ -1,19 +1,23 @@
 use crate::api::{ApiError, FederationApi};
+use crate::clients::transaction::TransactionBuilder;
 use crate::ln::gateway::LightningGateway;
 use crate::ln::{LnClient, LnClientError};
 use crate::mint::{MintClient, MintClientError, SpendableCoin};
 use crate::wallet::{WalletClient, WalletClientError};
 use crate::{api, OwnedClientContext};
+
 use bitcoin::{Address, Transaction};
 use lightning_invoice::Invoice;
 use minimint::config::ClientConfig;
 use minimint::modules::ln::contracts::{ContractId, IdentifyableContract};
 use minimint::modules::ln::{ContractAccount, ContractOrOfferOutput};
 use minimint::modules::mint::tiered::coins::Coins;
+
 use minimint::modules::wallet::txoproof::TxOutProof;
-use minimint::transaction as mint_tx;
-use minimint::transaction::{Output, TransactionItem};
-use minimint_api::db::batch::DbBatch;
+
+use minimint::modules::mint::BlindToken;
+use minimint::transaction::{Input, Output, TransactionItem};
+use minimint_api::db::batch::{Accumulator, BatchItem, DbBatch};
 use minimint_api::db::Database;
 use minimint_api::{Amount, TransactionId};
 use minimint_api::{OutPoint, PeerId};
@@ -85,7 +89,7 @@ impl UserClient {
         btc_transaction: Transaction,
         mut rng: R,
     ) -> Result<TransactionId, ClientError> {
-        let mut batch = DbBatch::new();
+        let mut tx = TransactionBuilder::default();
 
         let (peg_in_key, peg_in_proof) = self
             .wallet_client()
@@ -97,37 +101,24 @@ impl UserClient {
             return Err(ClientError::PegInAmountTooSmall);
         }
 
-        let (coin_finalization_data, coin_output) =
-            self.mint_client().create_coin_output(amount, &mut rng);
+        tx.input(&mut vec![peg_in_key], Input::Wallet(Box::new(peg_in_proof)));
 
-        let inputs = vec![mint_tx::Input::Wallet(Box::new(peg_in_proof))];
-        let outputs = vec![mint_tx::Output::Mint(coin_output)];
-        let txid = mint_tx::Transaction::tx_hash_from_parts(&inputs, &outputs);
+        self.submit_tx_with_change(tx, DbBatch::new(), &mut rng)
+            .await
+    }
 
-        self.mint_client().save_coin_finalization_data(
-            batch.transaction(),
-            OutPoint { txid, out_idx: 0 },
-            coin_finalization_data,
-        );
-
-        let peg_in_req_sig = minimint::transaction::agg_sign(
-            &[peg_in_key],
-            txid.as_hash(),
-            &self.context.secp,
-            &mut rng,
-        );
-
-        let mint_transaction = mint_tx::Transaction {
-            inputs,
-            outputs,
-            signature: Some(peg_in_req_sig),
-        };
-
-        let mint_tx_id = self
-            .context
-            .api
-            .submit_transaction(mint_transaction)
-            .await?;
+    async fn submit_tx_with_change<R: RngCore + CryptoRng>(
+        &self,
+        tx: TransactionBuilder,
+        mut batch: Accumulator<BatchItem>,
+        mut rng: R,
+    ) -> Result<TransactionId, ClientError> {
+        let change = tx.change_required(&self.context.config.fee_consensus);
+        let final_tx =
+            self.mint_client()
+                .finalize_change(change, batch.transaction(), tx, &mut rng);
+        let txid = final_tx.tx_hash();
+        let mint_tx_id = self.context.api.submit_transaction(final_tx).await?;
         // TODO: make check part of submit_transaction
         assert_eq!(
             txid, mint_tx_id,
@@ -150,96 +141,69 @@ impl UserClient {
         coins: Coins<SpendableCoin>,
         mut rng: R,
     ) -> Result<OutPoint, ClientError> {
-        const OUT_IDX: u64 = 0;
+        let mut tx = TransactionBuilder::default();
 
+        let (mut coin_keys, coin_input) = self.mint_client().create_coin_input_from_coins(coins)?;
+        tx.input(&mut coin_keys, Input::Mint(coin_input));
+        let txid = self
+            .submit_tx_with_change(tx, DbBatch::new(), &mut rng)
+            .await?;
+
+        Ok(OutPoint { txid, out_idx: 0 })
+    }
+
+    pub async fn pay_for_coins<R: RngCore + CryptoRng>(
+        &self,
+        coins: Coins<BlindToken>,
+        mut rng: R,
+    ) -> Result<OutPoint, ClientError> {
+        let mut batch = DbBatch::new();
+        let mut tx = TransactionBuilder::default();
+
+        let (mut coin_keys, coin_input) = self
+            .mint_client()
+            .create_coin_input(batch.transaction(), coins.amount())?;
+
+        tx.input(&mut coin_keys, Input::Mint(coin_input));
+        tx.output(Output::Mint(coins));
+        let txid = self.submit_tx_with_change(tx, batch, &mut rng).await?;
+
+        Ok(OutPoint { txid, out_idx: 0 })
+    }
+
+    pub fn receive_coins<R: RngCore + CryptoRng>(
+        &self,
+        amount: Amount,
+        rng: R,
+        create_tx: impl FnMut(Coins<BlindToken>) -> OutPoint,
+    ) {
         let mut batch = DbBatch::new();
 
-        let amount = coins.amount();
-        let (coin_keys, coin_input) = self.mint_client().create_coin_input_from_coins(coins)?;
-        // FIXME: implement fees (currently set to zero, so ignoring them works for now)
-        let (coin_finalization_data, coin_output) =
-            self.mint_client().create_coin_output(amount, &mut rng);
-
-        let inputs = vec![mint_tx::Input::Mint(coin_input)];
-        let outputs = vec![mint_tx::Output::Mint(coin_output)];
-        let txid = mint_tx::Transaction::tx_hash_from_parts(&inputs, &outputs);
-
-        self.mint_client().save_coin_finalization_data(
-            batch.transaction(),
-            OutPoint {
-                txid,
-                out_idx: OUT_IDX,
-            },
-            coin_finalization_data,
-        );
-
-        let signature = minimint::transaction::agg_sign(
-            &coin_keys,
-            txid.as_hash(),
-            &self.context.secp,
-            &mut rng,
-        );
-
-        let transaction = mint_tx::Transaction {
-            inputs,
-            outputs,
-            signature: Some(signature),
-        };
-
-        let mint_tx_id = self.context.api.submit_transaction(transaction).await?;
-        // TODO: make check part of submit_transaction
-        assert_eq!(
-            txid, mint_tx_id,
-            "Federation is faulty, returned wrong tx id."
-        );
+        self.mint_client()
+            .create_coin_output(batch.transaction(), amount, rng, create_tx);
 
         self.context.db.apply_batch(batch).expect("DB error");
-        Ok(OutPoint {
-            txid,
-            out_idx: OUT_IDX,
-        })
     }
 
     pub async fn peg_out<R: RngCore + CryptoRng>(
         &self,
         amt: bitcoin::Amount,
-        address: bitcoin::Address,
+        address: Address,
         mut rng: R,
     ) -> Result<TransactionId, ClientError> {
         let mut batch = DbBatch::new();
+        let mut tx = TransactionBuilder::default();
 
         let funding_amount = Amount::from(amt) + self.context.config.fee_consensus.fee_peg_out_abs;
-        let (coin_keys, coin_input) = self
+        let (mut coin_keys, coin_input) = self
             .mint_client()
             .create_coin_input(batch.transaction(), funding_amount)?;
         let pegout_output = self.wallet_client().create_pegout_output(amt, address);
 
-        let inputs = vec![mint_tx::Input::Mint(coin_input)];
-        let outputs = vec![mint_tx::Output::Wallet(pegout_output)];
-        let txid = mint_tx::Transaction::tx_hash_from_parts(&inputs, &outputs);
+        tx.input(&mut coin_keys, Input::Mint(coin_input));
+        tx.output(Output::Wallet(pegout_output));
 
-        let signature = minimint::transaction::agg_sign(
-            &coin_keys,
-            txid.as_hash(),
-            &self.context.secp,
-            &mut rng,
-        );
-
-        let transaction = mint_tx::Transaction {
-            inputs,
-            outputs,
-            signature: Some(signature),
-        };
-        let tx_id = transaction.tx_hash();
-
-        let mint_tx_id = self.context.api.submit_transaction(transaction).await?;
-        assert_eq!(
-            tx_id, mint_tx_id,
-            "Federation is faulty, returned wrong tx id."
-        );
-
-        self.context.db.apply_batch(batch).expect("DB error");
-        Ok(tx_id)
+        self.submit_tx_with_change(tx, batch, &mut rng).await
     }
 
     pub fn get_new_pegin_address<R: RngCore + CryptoRng>(&self, rng: R) -> Address {
@@ -296,6 +260,7 @@ impl UserClient {
         mut rng: R,
     ) -> Result<ContractId, ClientError> {
         let mut batch = DbBatch::new();
+        let mut tx = TransactionBuilder::default();
 
         let consensus_height = self.context.api.fetch_consensus_block_height().await?;
         let absolute_timelock = consensus_height + TIMELOCK;
@@ -319,35 +284,14 @@ impl UserClient {
         let ln_output = Output::LN(contract);
 
         let amount = ln_output.amount();
-        let (coin_keys, coin_input) = self
+        let (mut coin_keys, coin_input) = self
             .mint_client()
             .create_coin_input(batch.transaction(), amount)?;
 
-        let inputs = vec![mint_tx::Input::Mint(coin_input)];
-        let outputs = vec![ln_output];
-        let txid = mint_tx::Transaction::tx_hash_from_parts(&inputs, &outputs);
+        tx.input(&mut coin_keys, Input::Mint(coin_input));
+        tx.output(ln_output);
+        self.submit_tx_with_change(tx, batch, &mut rng).await?;
 
-        let signature = minimint::transaction::agg_sign(
-            &coin_keys,
-            txid.as_hash(),
-            &self.context.secp,
-            &mut rng,
-        );
-
-        let transaction = mint_tx::Transaction {
-            inputs,
-            outputs,
-            signature: Some(signature),
-        };
-
-        let mint_tx_id = self.context.api.submit_transaction(transaction).await?;
-        // TODO: make check part of submit_transaction
-        assert_eq!(
-            txid, mint_tx_id,
-            "Federation is faulty, returned wrong tx id."
-        );
-
-        self.context.db.apply_batch(batch).expect("DB error");
         Ok(contract_id)
     }
 

--- a/modules/minimint-wallet/src/lib.rs
+++ b/modules/minimint-wallet/src/lib.rs
@@ -667,9 +667,9 @@ impl Wallet {
                 .await;
         } else {
             panic!(
-                   "Median proposed consensus block height shrunk from {} to {}, the federation is broken",
-                   consensus_height, median_proposal
-               );
+                "Median proposed consensus block height shrunk from {} to {}, the federation is broken",
+                consensus_height, median_proposal
+            );
         }
 
         median_proposal


### PR DESCRIPTION
A PR for improving coin selection with change outputs based on @justinmoon's work:

- Refactored duplicate code for signing transactions into the `TransactionBuilder`
- The user clients will now make change for peg-out and LN invoice transactions (tested in integration tests) #1.
- `Coins::select_coins` will minimize the total `amount` of change (but not total number of coins which is far more difficult to compute) #11
- Fees are subtracted from the final change based on `Transaction::fee_amount` so that the client and federation are using the same fee calculation code
- The `save_coin_finalization_data` function is removed and replaced with a callback in `create_coin_output` to ensure coins are saved to the database
- New `receive_coins` and `pay_coins` functions in the `UserClient` allow users to make payments within the mint by submitting the payee’s blind tokens in a transaction