### PR TITLE
Expose lightning receive functionality to clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,6 +1618,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "async-trait",
+ "bitcoin_hashes",
  "clap",
  "cln-rpc",
  "futures",

--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies]
 async-std = { version = "1.6.0", features = ["attributes", "tokio1"] }
 async-trait = "0.1.52"
+bitcoin_hashes = "0.10.0"
 cln-rpc = "0.1"
 clap = { version = "3.1.18", features = ["derive"] }
 futures = "0.3.21"

--- a/minimint/src/consensus/conflictfilter.rs
+++ b/minimint/src/consensus/conflictfilter.rs
@@ -73,7 +73,7 @@ where
                     }
                 }
                 Input::LN(input) => {
-                    if !self.contract_set.insert(input.crontract_id) {
+                    if !self.contract_set.insert(input.contract_id) {
                         return None;
                     }
                 }

--- a/minimint/src/consensus/mod.rs
+++ b/minimint/src/consensus/mod.rs
@@ -246,8 +246,14 @@ where
                 .end_consensus_epoch(&epoch_peers, db_batch.transaction(), self.rng_gen.get_rng())
                 .await;
 
+            let mut drop_ln = self
+                .ln
+                .end_consensus_epoch(&epoch_peers, db_batch.transaction(), self.rng_gen.get_rng())
+                .await;
+
             drop_peers.append(&mut drop_wallet);
             drop_peers.append(&mut drop_mint);
+            drop_peers.append(&mut drop_ln);
 
             let mut batch_tx = db_batch.transaction();
             for peer in drop_peers {
@@ -289,6 +295,13 @@ where
                     .await
                     .into_iter()
                     .map(ConsensusItem::Mint),
+            )
+            .chain(
+                self.ln
+                    .consensus_proposal(self.rng_gen.get_rng())
+                    .await
+                    .into_iter()
+                    .map(ConsensusItem::LN),
             )
             .collect();
 

--- a/minimint/src/outcome.rs
+++ b/minimint/src/outcome.rs
@@ -1,5 +1,5 @@
 use minimint_api::FederationModule;
-use minimint_ln::contracts::incoming::{DecryptedPreimage, Preimage};
+use minimint_ln::contracts::incoming::{DecryptedPreimage, OfferId, Preimage};
 use minimint_ln::contracts::{AccountContractOutcome, ContractOutcome, OutgoingContractOutcome};
 use minimint_ln::LightningModule;
 use minimint_mint::SigResponse;
@@ -113,6 +113,16 @@ impl TryIntoOutcome for Preimage {
         }) = common_outcome
         {
             Ok(preimage)
+        } else {
+            Err(MismatchingVariant("ln::incoming", "other"))
+        }
+    }
+}
+
+impl TryIntoOutcome for OfferId {
+    fn try_into_outcome(common_outcome: OutputOutcome) -> Result<Self, MismatchingVariant> {
+        if let OutputOutcome::LN(minimint_ln::OutputOutcome::Offer { id }) = common_outcome {
+            Ok(id)
         } else {
             Err(MismatchingVariant("ln::incoming", "other"))
         }

--- a/mint-client/src/api.rs
+++ b/mint-client/src/api.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
+use bitcoin_hashes::sha256::Hash as Sha256Hash;
 use futures::{Future, StreamExt, TryFutureExt};
+use minimint::modules::ln::contracts::incoming::IncomingContractOffer;
 use minimint::modules::ln::contracts::ContractId;
 use minimint::modules::ln::ContractAccount;
 use minimint::outcome::{MismatchingVariant, TransactionStatus, TryIntoOutcome};
@@ -24,6 +26,9 @@ pub trait FederationApi: Send + Sync {
     // TODO: more generic module API extensibility
     /// Fetch ln contract state
     async fn fetch_contract(&self, contract: ContractId) -> Result<ContractAccount>;
+
+    /// Fetch preimage offer for incoming lightning payments
+    async fn fetch_offer(&self, payment_hash: Sha256Hash) -> Result<IncomingContractOffer>;
 
     /// Fetch the current consensus block height (trailing actual block height)
     async fn fetch_consensus_block_height(&self) -> Result<u64>;
@@ -127,6 +132,10 @@ impl FederationApi for HttpFederationApi {
 
     async fn fetch_consensus_block_height(&self) -> Result<u64> {
         self.get("/wallet/block_height").await
+    }
+
+    async fn fetch_offer(&self, payment_hash: Sha256Hash) -> Result<IncomingContractOffer> {
+        self.get(&format!("/ln/offer/{}", payment_hash)).await
     }
 }
 

--- a/mint-client/src/ln/incoming.rs
+++ b/mint-client/src/ln/incoming.rs
@@ -1,0 +1,21 @@
+use minimint::modules::ln::contracts::incoming::IncomingContract;
+use minimint::modules::ln::contracts::IdentifyableContract;
+use minimint::modules::ln::ContractInput;
+use minimint_api::encoding::{Decodable, Encodable};
+use minimint_api::Amount;
+
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub struct IncomingContractAccount {
+    pub amount: Amount,
+    pub contract: IncomingContract,
+}
+
+impl IncomingContractAccount {
+    pub fn claim(&self) -> ContractInput {
+        ContractInput {
+            contract_id: self.contract.contract_id(),
+            amount: self.amount,
+            witness: None,
+        }
+    }
+}

--- a/mint-client/src/ln/outgoing.rs
+++ b/mint-client/src/ln/outgoing.rs
@@ -17,10 +17,9 @@ pub struct OutgoingContractAccount {
 }
 
 impl OutgoingContractAccount {
-    #[allow(dead_code)]
     pub fn claim(&self, preimage: Preimage) -> ContractInput {
         ContractInput {
-            crontract_id: self.contract.contract_id(),
+            contract_id: self.contract.contract_id(),
             amount: self.amount,
             witness: Some(preimage),
         }
@@ -28,7 +27,7 @@ impl OutgoingContractAccount {
 
     pub fn refund(&self) -> ContractInput {
         ContractInput {
-            crontract_id: self.contract.contract_id(),
+            contract_id: self.contract.contract_id(),
             amount: self.amount,
             witness: None,
         }

--- a/mint-client/src/mint/mod.rs
+++ b/mint-client/src/mint/mod.rs
@@ -438,6 +438,7 @@ mod tests {
     use async_trait::async_trait;
     use bitcoin::hashes::Hash;
     use futures::executor::block_on;
+    use minimint::modules::ln::contracts::incoming::IncomingContractOffer;
     use minimint::modules::ln::contracts::ContractId;
     use minimint::modules::ln::ContractAccount;
     use minimint::modules::mint::config::MintClientConfig;
@@ -489,6 +490,13 @@ mod tests {
 
         async fn fetch_consensus_block_height(&self) -> crate::api::Result<u64> {
             unimplemented!()
+        }
+
+        async fn fetch_offer(
+            &self,
+            _payment_hash: bitcoin::hashes::sha256::Hash,
+        ) -> crate::api::Result<IncomingContractOffer> {
+            unimplemented!();
         }
     }
 

--- a/mint-client/src/wallet/mod.rs
+++ b/mint-client/src/wallet/mod.rs
@@ -137,7 +137,9 @@ mod tests {
     use crate::OwnedClientContext;
     use async_trait::async_trait;
     use bitcoin::Address;
+
     use minimint::config::FeeConsensus;
+    use minimint::modules::ln::contracts::incoming::IncomingContractOffer;
     use minimint::modules::ln::contracts::ContractId;
     use minimint::modules::ln::ContractAccount;
     use minimint::modules::wallet::bitcoind::test::{FakeBitcoindRpc, FakeBitcoindRpcController};
@@ -186,6 +188,13 @@ mod tests {
 
         async fn fetch_consensus_block_height(&self) -> crate::api::Result<u64> {
             unimplemented!()
+        }
+
+        async fn fetch_offer(
+            &self,
+            _payment_hash: bitcoin::hashes::sha256::Hash,
+        ) -> crate::api::Result<IncomingContractOffer> {
+            unimplemented!();
         }
     }
 

--- a/modules/minimint-ln/src/config.rs
+++ b/modules/minimint-ln/src/config.rs
@@ -29,7 +29,7 @@ impl GenerateConfig for LightningModuleConfig {
         mut rng: impl RngCore + CryptoRng,
     ) -> (BTreeMap<PeerId, Self>, Self::ClientConfig) {
         let threshold = peers.len() - max_evil;
-        let sks = threshold_crypto::SecretKeySet::random(threshold, &mut rng);
+        let sks = threshold_crypto::SecretKeySet::random(threshold - 1, &mut rng);
         let pks = sks.public_keys();
 
         let server_cfg = peers

--- a/modules/minimint-ln/src/contracts/incoming.rs
+++ b/modules/minimint-ln/src/contracts/incoming.rs
@@ -15,6 +15,12 @@ pub struct IncomingContractOffer {
     pub encrypted_preimage: EncryptedPreimage,
 }
 
+impl IncomingContractOffer {
+    pub fn id(&self) -> OfferId {
+        OfferId::from_hash(self.hash)
+    }
+}
+
 // FIXME: the protocol currently envisions the use of a pub key as preimage. This is bad for privacy
 // though since pub keys are distinguishable from randomness and the payer would learn the recipient
 // is using a federated mint. Probably best to just hash the key before.
@@ -105,9 +111,7 @@ impl EncryptedPreimage {
 
 impl IdentifyableContract for IncomingContract {
     fn contract_id(&self) -> ContractId {
-        let mut engine = ContractId::engine();
-        Encodable::consensus_encode(self, &mut engine).expect("Hashing never fails");
-        ContractId::from_engine(engine)
+        ContractId::from_hash(self.hash)
     }
 }
 

--- a/modules/minimint-ln/tests/ln_contracts.rs
+++ b/modules/minimint-ln/tests/ln_contracts.rs
@@ -51,7 +51,7 @@ async fn test_account() {
     };
 
     let account_input = ContractInput {
-        crontract_id: contract.contract_id(),
+        contract_id: contract.contract_id(),
         amount: Amount::from_sat(42),
         witness: None,
     };
@@ -114,7 +114,7 @@ async fn test_outgoing() {
 
     // Error: Missing preimage
     let account_input_no_witness = ContractInput {
-        crontract_id: contract.contract_id(),
+        contract_id: contract.contract_id(),
         amount: Amount::from_sat(42),
         witness: None,
     };
@@ -123,7 +123,7 @@ async fn test_outgoing() {
 
     // Ok
     let account_input_witness = ContractInput {
-        crontract_id: contract.contract_id(),
+        contract_id: contract.contract_id(),
         amount: Amount::from_sat(42),
         witness: Some(Preimage(preimage)),
     };
@@ -200,7 +200,7 @@ async fn test_incoming() {
     };
 
     let incoming_input = ContractInput {
-        crontract_id: contract.contract_id(),
+        contract_id: contract.contract_id(),
         amount: Amount::from_sat(42),
         witness: None,
     };


### PR DESCRIPTION
This PR exposes the "incoming" contracts from the lightning module.

It doesn't add any new user-facing functionality yet. I have previously sketched out how the gateway daemon and user client CLI would need to change (https://github.com/fedimint/minimint/pull/101) but want to get the core library code merged first and then complete that PR.