### PR TITLE
Drop non-contributing peers in mint module fedimint/minimint#72

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,7 @@ dependencies = [
  "clightningrpc",
  "cln-rpc",
  "futures",
+ "hbbft",
  "itertools",
  "lightning",
  "lightning-invoice",

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -26,3 +26,4 @@ serde = { version = "1.0.118", features = [ "derive" ] }
 tokio = { version = "1.0.1", features = ["full"] }
 tracing ="0.1.22"
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }
+hbbft = { git = "https://github.com/fedimint/hbbft", branch = "minimint" }

--- a/integrationtests/README.md
+++ b/integrationtests/README.md
@@ -25,7 +25,6 @@ In order to simulate consensus we have to tell the federation how many epochs to
 ```rust
 fed.run_consensus_epochs(2).await;
 ```
-Note that because HBBFT and consensus processing are concurrent you must always add an additional epoch to consume a `ConsensusOutcome` before any newly proposed `ConsensusItems` will be processed.
 
 ## Running tests
 Tests run by default with fake Lightning and Bitcoin services for fast concurrent testing that succeeds in any environment, but can also be run against real services.

--- a/minimint-api/src/module/testing.rs
+++ b/minimint-api/src/module/testing.rs
@@ -5,6 +5,7 @@ use crate::db::Database;
 use crate::module::http;
 use crate::module::interconnect::ModuleInterconect;
 use crate::{Amount, FederationModule, InputMeta, OutPoint, PeerId};
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -109,6 +110,7 @@ where
             );
         }
 
+        let peers: HashSet<PeerId> = self.members.iter().map(|p| p.0).collect();
         for (_peer, member, db) in &mut self.members {
             let mut batch = DbBatch::new();
 
@@ -135,7 +137,7 @@ where
 
             let mut batch = DbBatch::new();
             member
-                .end_consensus_epoch(batch.transaction(), &mut rng)
+                .end_consensus_epoch(&peers, batch.transaction(), &mut rng)
                 .await;
 
             (db as &mut dyn Database)

--- a/minimint-derive/src/lib.rs
+++ b/minimint-derive/src/lib.rs
@@ -129,9 +129,7 @@ pub fn derive_encodable(input: TokenStream) -> TokenStream {
                         .fields
                         .iter()
                         .enumerate()
-                        .map(|(idx, _)| {
-                            format_ident!("bound_{}", idx)
-                        })
+                        .map(|(idx, _)| format_ident!("bound_{}", idx))
                         .collect::<Vec<_>>();
                     quote! {
                         #ident::#variant_ident(#(#variant_fields,)*) => {
@@ -140,15 +138,8 @@ pub fn derive_encodable(input: TokenStream) -> TokenStream {
                         }
                     }
                 } else {
-                    let variant_fields = variant
-                        .fields
-                        .iter()
-                        .map(|field| {
-                            field
-                                .ident
-                                .clone().unwrap()
-                        })
-                        .collect::<Vec<_>>();
+                    let variant_fields =
+                        variant.fields.iter().map(|field| field.ident.clone().unwrap()).collect::<Vec<_>>();
                     quote! {
                         #ident::#variant_ident { #(#variant_fields,)*} => {
                             len += Encodable::consensus_encode(&(#variant_idx as u64), &mut writer)?;

--- a/minimint/src/db.rs
+++ b/minimint/src/db.rs
@@ -2,11 +2,12 @@ use crate::consensus::AcceptedTransaction;
 use crate::transaction::Transaction;
 use minimint_api::db::DatabaseKeyPrefixConst;
 use minimint_api::encoding::{Decodable, Encodable};
-use minimint_api::TransactionId;
+use minimint_api::{PeerId, TransactionId};
 use std::fmt::Debug;
 
 pub const DB_PREFIX_PROPOSED_TRANSACTION: u8 = 0x01;
 pub const DB_PREFIX_ACCEPTED_TRANSACTION: u8 = 0x02;
+pub const DB_PREFIX_DROP_PEER: u8 = 0x03;
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct ProposedTransactionKey(pub TransactionId);
@@ -33,4 +34,22 @@ impl DatabaseKeyPrefixConst for AcceptedTransactionKey {
     const DB_PREFIX: u8 = DB_PREFIX_ACCEPTED_TRANSACTION;
     type Key = Self;
     type Value = AcceptedTransaction;
+}
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct DropPeerKey(pub PeerId);
+
+impl DatabaseKeyPrefixConst for DropPeerKey {
+    const DB_PREFIX: u8 = DB_PREFIX_DROP_PEER;
+    type Key = Self;
+    type Value = ();
+}
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct DropPeerKeyPrefix;
+
+impl DatabaseKeyPrefixConst for DropPeerKeyPrefix {
+    const DB_PREFIX: u8 = DB_PREFIX_DROP_PEER;
+    type Key = DropPeerKey;
+    type Value = ();
 }

--- a/modules/minimint-ln/src/lib.rs
+++ b/modules/minimint-ln/src/lib.rs
@@ -35,6 +35,7 @@ use minimint_api::{Amount, FederationModule, PeerId};
 use minimint_api::{InputMeta, OutPoint};
 use secp256k1::rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::sync::Arc;
 use thiserror::Error;
 use tracing::{debug, error, info_span, instrument, trace, warn};
@@ -372,9 +373,10 @@ impl FederationModule for LightningModule {
     #[instrument(skip_all)]
     async fn end_consensus_epoch<'a>(
         &'a self,
+        _consensus_peers: &HashSet<PeerId>,
         mut batch: BatchTx<'a>,
         _rng: impl RngCore + CryptoRng + 'a,
-    ) {
+    ) -> Vec<PeerId> {
         // Decrypt preimages
         let preimage_decraption_shares = self
             .db
@@ -479,6 +481,9 @@ impl FederationModule for LightningModule {
             batch.append_insert(outcome_db_key, outcome);
         }
         batch.commit();
+
+        // FIXME should use to drop non-contributing peers
+        vec![]
     }
 
     fn output_status(&self, out_point: OutPoint) -> Option<Self::TxOutputOutcome> {


### PR DESCRIPTION
- Introduces a new `DropPeerKey` in the database that allows a module to drop a misbehaving peer from HBBFT consensus
- During `end_consensus` peers that do not contribute shares (if we have) or contribute bad shares will be dropped
- Implementation covers the mint module only, need follow-up work to handle similar situations in ln and wallet
- Also the client and federation doesn't recover well if a federation node goes down eventually we will need to make that more robust