### PR TITLE
Implement outpoint polling in FederationApi

### DIFF
--- a/minimint/src/outcome.rs
+++ b/minimint/src/outcome.rs
@@ -1,5 +1,6 @@
 use minimint_api::FederationModule;
-use minimint_ln::contracts::ContractOutcome;
+use minimint_ln::contracts::incoming::{DecryptedPreimage, Preimage};
+use minimint_ln::contracts::{AccountContractOutcome, ContractOutcome, OutgoingContractOutcome};
 use minimint_ln::LightningModule;
 use minimint_mint::SigResponse;
 use serde::{Deserialize, Serialize};
@@ -49,12 +50,12 @@ impl Final for OutputOutcome {
             OutputOutcome::LN(minimint_ln::OutputOutcome::Offer { .. }) => true,
             OutputOutcome::LN(minimint_ln::OutputOutcome::Contract { outcome, .. }) => {
                 match outcome {
-                    ContractOutcome::Account => true,
+                    ContractOutcome::Account(_) => true,
                     ContractOutcome::Incoming(
                         minimint_ln::contracts::incoming::DecryptedPreimage::Some(_),
                     ) => true,
                     ContractOutcome::Incoming(_) => false,
-                    ContractOutcome::Outgoing => true,
+                    ContractOutcome::Outgoing(_) => true,
                 }
             }
         }
@@ -100,6 +101,48 @@ impl TryIntoOutcome for minimint_ln::OutputOutcome {
             OutputOutcome::Mint(_) => Err(MismatchingVariant("ln", "mint")),
             OutputOutcome::Wallet(_) => Err(MismatchingVariant("ln", "wallet")),
             OutputOutcome::LN(outcome) => Ok(outcome),
+        }
+    }
+}
+
+impl TryIntoOutcome for Preimage {
+    fn try_into_outcome(common_outcome: OutputOutcome) -> Result<Self, MismatchingVariant> {
+        if let OutputOutcome::LN(minimint_ln::OutputOutcome::Contract {
+            outcome: ContractOutcome::Incoming(DecryptedPreimage::Some(preimage)),
+            ..
+        }) = common_outcome
+        {
+            Ok(preimage)
+        } else {
+            Err(MismatchingVariant("ln::incoming", "other"))
+        }
+    }
+}
+
+impl TryIntoOutcome for AccountContractOutcome {
+    fn try_into_outcome(common_outcome: OutputOutcome) -> Result<Self, MismatchingVariant> {
+        if let OutputOutcome::LN(minimint_ln::OutputOutcome::Contract {
+            outcome: ContractOutcome::Account(o),
+            ..
+        }) = common_outcome
+        {
+            Ok(o)
+        } else {
+            Err(MismatchingVariant("ln::account", "other"))
+        }
+    }
+}
+
+impl TryIntoOutcome for OutgoingContractOutcome {
+    fn try_into_outcome(common_outcome: OutputOutcome) -> Result<Self, MismatchingVariant> {
+        if let OutputOutcome::LN(minimint_ln::OutputOutcome::Contract {
+            outcome: ContractOutcome::Outgoing(o),
+            ..
+        }) = common_outcome
+        {
+            Ok(o)
+        } else {
+            Err(MismatchingVariant("ln::outgoing", "other"))
         }
     }
 }

--- a/mint-client/src/main.rs
+++ b/mint-client/src/main.rs
@@ -143,13 +143,13 @@ async fn main() {
         Command::LnPay { bolt11 } => {
             let http = reqwest::Client::new();
 
-            let contract_id = client
+            let (contract_id, outpoint) = client
                 .fund_outgoing_ln_contract(&cfg.gateway, bolt11, &mut rng)
                 .await
                 .expect("Not enough coins");
 
             client
-                .wait_contract_timeout(contract_id, Duration::from_secs(5))
+                .await_outgoing_contract_acceptance(outpoint)
                 .await
                 .expect("Contract wasn't accepted in time");
 

--- a/modules/minimint-ln/src/contracts/mod.rs
+++ b/modules/minimint-ln/src/contracts/mod.rs
@@ -46,10 +46,16 @@ pub enum FundedContract {
 /// the user (the decrypted preimage).
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub enum ContractOutcome {
-    Account,
+    Account(AccountContractOutcome),
     Incoming(incoming::DecryptedPreimage),
-    Outgoing,
+    Outgoing(OutgoingContractOutcome),
 }
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+pub struct AccountContractOutcome {}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
+pub struct OutgoingContractOutcome {}
 
 impl IdentifyableContract for Contract {
     fn contract_id(&self) -> ContractId {
@@ -76,9 +82,9 @@ impl Contract {
     /// the contract type it is not yet final.
     pub fn to_outcome(&self) -> ContractOutcome {
         match self {
-            Contract::Account(_) => ContractOutcome::Account,
+            Contract::Account(_) => ContractOutcome::Account(AccountContractOutcome {}),
             Contract::Incoming(_) => ContractOutcome::Incoming(DecryptedPreimage::Pending),
-            Contract::Outgoing(_) => ContractOutcome::Outgoing,
+            Contract::Outgoing(_) => ContractOutcome::Outgoing(OutgoingContractOutcome {}),
         }
     }
 

--- a/modules/minimint-ln/tests/ln_contracts.rs
+++ b/modules/minimint-ln/tests/ln_contracts.rs
@@ -7,7 +7,10 @@ use minimint_ln::contracts::incoming::{
     DecryptedPreimage, EncryptedPreimage, IncomingContract, IncomingContractOffer,
 };
 use minimint_ln::contracts::outgoing::{OutgoingContract, Preimage};
-use minimint_ln::contracts::{Contract, ContractOutcome, IdentifyableContract};
+use minimint_ln::contracts::{
+    AccountContractOutcome, Contract, ContractOutcome, IdentifyableContract,
+    OutgoingContractOutcome,
+};
 use minimint_ln::{
     ContractInput, ContractOrOfferOutput, ContractOutput, LightningModule, LightningModuleError,
     OutputOutcome,
@@ -42,7 +45,7 @@ async fn test_account() {
     fed.consensus_round(&[], &outputs).await;
     match fed.output_outcome(account_out_point).unwrap() {
         OutputOutcome::Contract { outcome, .. } => {
-            assert_eq!(outcome, ContractOutcome::Account);
+            assert_eq!(outcome, ContractOutcome::Account(AccountContractOutcome {}));
         }
         _ => panic!(),
     };
@@ -98,7 +101,10 @@ async fn test_outgoing() {
     fed.consensus_round(&[], &outputs).await;
     match fed.output_outcome(outgoing_out_point).unwrap() {
         OutputOutcome::Contract { outcome, .. } => {
-            assert_eq!(outcome, ContractOutcome::Outgoing);
+            assert_eq!(
+                outcome,
+                ContractOutcome::Outgoing(OutgoingContractOutcome {})
+            );
         }
         _ => panic!(),
     };


### PR DESCRIPTION
While working on the lightning receive functionality I ended up with 4 different ways to poll whether a given transaction outpoint was accepted by the federation. This seemed complex and confusing.

This PR attempts to move this polling logic to the `impl` of `FederationApi`. It adds concrete variants to `OutputOutcome` which impl `TryIntoOutcome` to assist checking that the outcome observed is what we expected -- e.g. a lightning preimage was decrypted. In the future implementors of `FederationApi` should be able to override this polling implementation with websockets etc.

In order to always poll by `OutPoint` (instead of `OrderId` or `ContractId` etc) I had to make a couple functions return `OutPoint` in addition to what they previously returned.

I also made `UserClient::ln_client()` public. Is this bad? `UserClient::mint_client()` was already public. Seems like all or none should be.