### PR TITLE
Flakifying minimint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check 
+          args: --all -- --check
   build_wasm:
     name: Build (wasm32)
     runs-on: ubuntu-latest
@@ -77,6 +77,19 @@ jobs:
           nix_path: nixpkgs=channel:nixos-22.05
       - uses: cachix/cachix-action@v10
         with:
-          name: mini
-          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+          name: fedimint
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix-build
+  nix-flake:
+    name: Nix-flake Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-22.05
+      - uses: cachix/cachix-action@v10
+        with:
+          name: fedimint
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix build

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Happy hacking!
 
 ## Running MiniMint locally
 
-MiniMint is tested and developed using rust `stable`, you can get it through your package manager or from [rustup.rs](https://rustup.rs/).
+MiniMint is tested and developed using rust `stable`, you can get it through your package manager or from [rustup.rs](https://rustup.rs/). If you use nix/nixos you can refer to our [nix](docs/nix_instructions.md) documentation.
 
 MiniMint consists of three kinds of services:
 * federation member nodes (`server` binary) which make up the federation and run the consensus protocol among each other.

--- a/docs/nix_instructions.md
+++ b/docs/nix_instructions.md
@@ -1,29 +1,34 @@
 ### Working with Nix
 
+To install nix:
+```shell
+sh <(curl -L https://nixos.org/nix/install) --no-daemon
+```
+
 Clone the repository:
 ```
 git clone git@github.com:fedimint/minimint.git
 ```
 Enter development shell: 
-```
+```nix
 nix-shell
 ```
 Setup development environment locally:
-```
+```nix
 nix-build default.nix
 ```
 Run integration tests with nix-shell:
-```
+```nix
 nix-shell --command ./scripts/integrationtest.sh
 ```
 
 ### nix-flakes:
 
-Minimint can be installed using nix-flakes by running: 
-```
+Minimint can be installed without cloning the repository using nix-flakes by running: 
+```nix
 nix run github:fedimint/minimint
 ```
 To build a specific branch:
-```
+```nix
 nix run github:fedimint/minimint/branch_name
 ```

--- a/docs/nix_instructions.md
+++ b/docs/nix_instructions.md
@@ -1,0 +1,29 @@
+### Working with Nix
+
+Clone the repository:
+```
+git clone git@github.com:fedimint/minimint.git
+```
+Enter development shell: 
+```
+nix-shell
+```
+Setup development environment locally:
+```
+nix-build default.nix
+```
+Run integration tests with nix-shell:
+```
+nix-shell --command ./scripts/integrationtest.sh
+```
+
+### nix-flakes:
+
+Minimint can be installed using nix-flakes by running: 
+```
+nix run github:fedimint/minimint
+```
+To build a specific branch:
+```
+nix run github:fedimint/minimint/branch_name
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,97 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655078190,
+        "narHash": "sha256-ZFzXWRyN/YpvkrOKH+LHHX9SvfB7jLFNHt6yUqlZPbM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "4a3f1394b2bc7f735f43998fc15c94579ea1d13c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1655456688,
+        "narHash": "sha256-j2trI5gv2fnHdfUQFBy957avCPxxzCqE8R+TOYHPSRE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d17a56d90ecbd1b8fc908d49598fb854ef188461",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    crane.url = "github:ipetkov/crane";
+    crane.inputs.nixpkgs.follows = "nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, crane, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        craneLib = crane.lib.${system};
+
+        commonArgs = {
+          src = ./.;
+
+          buildInputs = with pkgs; [
+            openssl
+            pkg-config
+            perl
+          ];
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+        };
+
+        cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {
+          pname = "minimint";
+        });
+
+        myCrateClippy = craneLib.cargoClippy (commonArgs // {
+          inherit cargoArtifacts;
+          cargoClippyExtraArgs = "-- --deny warnings";
+        });
+
+        myCrate = craneLib.buildPackage (commonArgs // {
+          inherit cargoArtifacts;
+        });
+
+        myCrateCoverage = craneLib.cargoTarpaulin (commonArgs // {
+          inherit cargoArtifacts;
+        });
+      in
+      {
+        packages.default = myCrate;
+        checks = {
+         inherit
+           myCrate
+           myCrateClippy
+           myCrateCoverage;
+        };
+      });
+}


### PR DESCRIPTION
cargo2nix has issues finding lib,sys crates so switching to crane (offers better caching support) untill the issue is fixed upstream. After this pr minimint can be installed using `nix run github:fedimint/minimint` and for a specific branch we can use `nix run github:fedimint/minimint/branch_name`