### PR TITLE
Replace tempdir with tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,7 +1763,7 @@ dependencies = [
  "serde_json",
  "sled",
  "tbs",
- "tempdir",
+ "tempfile",
  "test-log",
  "thiserror",
  "tracing",
@@ -3101,16 +3101,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "sha3",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/minimint-api/Cargo.toml
+++ b/minimint-api/Cargo.toml
@@ -29,6 +29,6 @@ tracing ="0.1.22"
 getrandom = { version = "0.2.0", features = [ "js" ] }
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3.3.0"
 test-log = { version = "0.2", features = [ "trace" ], default-features = false }
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }

--- a/minimint-api/src/db/sled_impl.rs
+++ b/minimint-api/src/db/sled_impl.rs
@@ -91,7 +91,10 @@ mod tests {
 
     #[test_log::test]
     fn test_basic_rw() {
-        let path = tempdir::TempDir::new("fcb-sled-test").unwrap();
+        let path = tempfile::Builder::new()
+            .prefix("fcb-sled-test")
+            .tempdir()
+            .unwrap();
         let db = sled::open(path).unwrap();
         crate::db::tests::test_db_impl(Arc::new(db.open_tree("default").unwrap()));
     }


### PR DESCRIPTION
from https://github.com/rust-lang-deprecated/tempdir

> Deprecation Note
> The tempdir crate is being merged into tempfile and is available in 3.x.