### PR TITLE
organize utlility functions in 'utils' (client-lib)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,9 +1976,12 @@ name = "mint-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.13.0",
+ "bincode",
  "bitcoin",
  "bitcoin_hashes",
  "futures",
+ "hex",
  "lightning",
  "lightning-invoice",
  "minimint-api",
@@ -2000,12 +2003,9 @@ dependencies = [
 name = "mint-client-cli"
 version = "0.1.0"
 dependencies = [
- "base64 0.13.0",
- "bincode",
  "bitcoin",
  "bitcoin_hashes",
  "clap",
- "hex",
  "lightning-invoice",
  "minimint-api",
  "minimint-core",

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -6,12 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = "0.13.0"
-bincode = "1.3.1"
 bitcoin = "0.27.0"
 bitcoin_hashes = "0.10.0"
 clap = { version = "3.1.18", features = ["derive"] }
-hex = "0.4.3"
 lightning-invoice = "0.14.0"
 mint-client = { path = "../client-lib" }
 minimint-api = { path = "../../minimint-api" }

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -1,15 +1,14 @@
 use bitcoin::{Address, Transaction};
 use bitcoin_hashes::hex::ToHex;
 use clap::Parser;
-use minimint_api::encoding::Decodable;
 use minimint_api::Amount;
 use minimint_core::config::load_from_file;
 use minimint_core::modules::mint::tiered::coins::Coins;
 use minimint_core::modules::wallet::txoproof::TxOutProof;
 use mint_client::mint::SpendableCoin;
+use mint_client::utils::{from_hex, parse_bitcoin_amount, parse_coins, serialize_coins};
 use mint_client::{ClientAndGatewayConfig, UserClient};
 use serde::{Deserialize, Serialize};
-use std::error::Error;
 use std::path::PathBuf;
 use std::time::Duration;
 use tracing::{error, info};
@@ -166,25 +165,4 @@ async fn main() {
                 .unwrap();
         }
     }
-}
-
-fn parse_coins(s: &str) -> Coins<SpendableCoin> {
-    let bytes = base64::decode(s).unwrap();
-    bincode::deserialize(&bytes).unwrap()
-}
-
-fn serialize_coins(c: &Coins<SpendableCoin>) -> String {
-    let bytes = bincode::serialize(&c).unwrap();
-    base64::encode(&bytes)
-}
-
-fn from_hex<D: Decodable>(s: &str) -> Result<D, Box<dyn Error + Send + Sync>> {
-    let bytes = hex::decode(s)?;
-    Ok(D::consensus_decode(std::io::Cursor::new(bytes))?)
-}
-
-fn parse_bitcoin_amount(
-    s: &str,
-) -> Result<bitcoin::Amount, bitcoin::util::amount::ParseAmountError> {
-    bitcoin::Amount::from_str_in(s, bitcoin::Denomination::Satoshi)
 }

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -8,9 +8,12 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1.52"
+base64 = "0.13.0"
+bincode = "1.3.1"
 bitcoin = "0.27.0"
 bitcoin_hashes = "0.10.0"
 futures = "0.3.9"
+hex = "0.4.3"
 lightning-invoice = "0.14.0"
 lightning = "0.0.106"
 miniscript = "6.0.0"

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod clients;
 pub mod ln;
 pub mod mint;
+pub mod utils;
 pub mod wallet;
 
 use crate::api::FederationApi;

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -1,0 +1,25 @@
+use crate::mint::SpendableCoin;
+use minimint_api::encoding::Decodable;
+use minimint_core::modules::mint::tiered::coins::Coins;
+use std::error::Error;
+
+pub fn parse_coins(s: &str) -> Coins<SpendableCoin> {
+    let bytes = base64::decode(s).unwrap();
+    bincode::deserialize(&bytes).unwrap()
+}
+
+pub fn serialize_coins(c: &Coins<SpendableCoin>) -> String {
+    let bytes = bincode::serialize(&c).unwrap();
+    base64::encode(&bytes)
+}
+
+pub fn from_hex<D: Decodable>(s: &str) -> Result<D, Box<dyn Error + Send + Sync>> {
+    let bytes = hex::decode(s)?;
+    Ok(D::consensus_decode(std::io::Cursor::new(bytes))?)
+}
+
+pub fn parse_bitcoin_amount(
+    s: &str,
+) -> Result<bitcoin::Amount, bitcoin::util::amount::ParseAmountError> {
+    bitcoin::Amount::from_str_in(s, bitcoin::Denomination::Satoshi)
+}


### PR DESCRIPTION
the fn moved are also useful for future modules (clientd for example) and should not only be in the mint-client bin