### PR TITLE
Added rocksdb with transactions using Yiyuanliu branch of rust-rocksdb.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
 
 [[package]]
 name = "arrayvec"
@@ -49,13 +49,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -166,6 +166,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote 1.0.21",
+ "regex",
+ "rustc-hash",
+ "shlex",
 ]
 
 [[package]]
@@ -287,16 +306,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -324,8 +377,8 @@ dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -513,8 +566,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -601,8 +654,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -698,8 +751,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -753,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -784,6 +837,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
@@ -1081,9 +1140,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1239,16 +1307,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libc"
-version = "0.2.126"
+name = "lazycell"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libc"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+
+[[package]]
+name = "libloading"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libm"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da83a57f3f5ba3680950aa3cbc806fc297bc0b289d42e8942ed528ace71b8145"
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.7.0+7.1.2"
+source = "git+https://github.com/fedimint/rust-rocksdb?branch=minimint#8b9868b7b44db337cbc7421b657533c59aa8c712"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "lightning"
@@ -1289,6 +1398,7 @@ dependencies = [
  "minimint-api",
  "mint-client",
  "rand 0.6.5",
+ "rocksdb",
  "secp256k1",
  "serde",
  "serde_json",
@@ -1360,6 +1470,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "minimint"
 version = "0.1.0"
 dependencies = [
@@ -1383,6 +1499,7 @@ dependencies = [
  "rand 0.6.5",
  "rayon",
  "rcgen",
+ "rocksdb",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -1415,6 +1532,7 @@ dependencies = [
  "minimint-derive",
  "rand 0.6.5",
  "rand 0.7.3",
+ "rocksdb",
  "secp256k1-zkp",
  "serde",
  "serde_json",
@@ -1460,8 +1578,8 @@ version = "0.1.0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -1618,6 +1736,7 @@ dependencies = [
  "minimint-core",
  "mint-client",
  "rand 0.6.5",
+ "rocksdb",
  "serde",
  "serde_json",
  "sled",
@@ -1636,6 +1755,16 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1832,6 +1961,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pem"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,8 +1997,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -1879,6 +2014,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,8 +2033,8 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
  "version_check",
 ]
 
@@ -1904,15 +2045,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.20",
+ "quote 1.0.21",
  "version_check",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
@@ -1925,9 +2066,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -2285,6 +2426,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.18.0"
+source = "git+https://github.com/fedimint/rust-rocksdb?branch=minimint#8b9868b7b44db337cbc7421b657533c59aa8c712"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,18 +2466,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
  "base64",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "schannel"
@@ -2427,29 +2577,29 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
+checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
+checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa",
  "ryu",
@@ -2501,6 +2651,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2604,12 +2760,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
- "quote 1.0.20",
+ "quote 1.0.21",
  "unicode-ident",
 ]
 
@@ -2680,8 +2836,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -2692,22 +2848,22 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -2762,10 +2918,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
+checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
 dependencies = [
+ "js-sys",
  "libc",
  "num_threads",
 ]
@@ -2822,8 +2979,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -2945,8 +3102,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -3031,9 +3188,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-normalization"
@@ -3101,9 +3258,9 @@ dependencies = [
  "lazy_static",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.20",
+ "quote 1.0.21",
  "regex",
- "syn 1.0.98",
+ "syn 1.0.99",
  "validator_types",
 ]
 
@@ -3118,6 +3275,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3169,8 +3332,8 @@ dependencies = [
  "log",
  "once_cell",
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -3192,7 +3355,7 @@ version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
- "quote 1.0.20",
+ "quote 1.0.21",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3203,8 +3366,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
- "quote 1.0.20",
- "syn 1.0.98",
+ "quote 1.0.21",
+ "syn 1.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3350,3 +3513,13 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+
+[[package]]
+name = "zstd-sys"
+version = "1.6.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+dependencies = [
+ "cc",
+ "libc",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ resolver = "2"
 
 [patch.crates-io]
 bitcoin_hashes = { version = "0.10.0", git = 'https://github.com/fedimint/bitcoin_hashes', branch = 'minimint' }
+rocksdb = { git = "https://github.com/fedimint/rust-rocksdb", branch = "minimint" }
 secp256k1-zkp = { git = "https://github.com/fedimint/rust-secp256k1-zkp/", branch = "sanket-pr" }
 cln-plugin = { git = "https://github.com/ElementsProject/lightning", rev = "42783aa" }
 cln-rpc = { git = "https://github.com/ElementsProject/lightning", rev = "42783aa" }

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -11,9 +11,10 @@ bitcoin_hashes = "0.10.0"
 clap = { version = "3.1.18", features = ["derive"] }
 lightning-invoice = "0.17.0"
 mint-client = { path = "../client-lib" }
-minimint-api = { path = "../../minimint-api" }
+minimint-api = { path = "../../minimint-api", features = ["rocksdb"] }
 minimint-core = { path = "../../minimint-core" }
 rand = "0.6.5"
+rocksdb = { git = "https://github.com/fedimint/rust-rocksdb", branch = "minimint" }
 serde = { version = "1.0.118", features = [ "derive" ] }
 sled = "0.34.6"
 tokio = { version = "1.19.2", features = ["full"] }

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -97,10 +97,8 @@ async fn main() {
     let cfg_path = opts.workdir.join("client.json");
     let db_path = opts.workdir.join("client.db");
     let cfg: UserClientConfig = load_from_file(&cfg_path);
-    let db = sled::open(&db_path)
-        .unwrap()
-        .open_tree("mint-client")
-        .unwrap();
+    let db: rocksdb::OptimisticTransactionDB<rocksdb::SingleThreaded> =
+        rocksdb::OptimisticTransactionDB::open_default(&db_path).unwrap();
 
     let mut rng = rand::rngs::OsRng::new().unwrap();
 

--- a/default.nix
+++ b/default.nix
@@ -9,10 +9,13 @@ in naersk.buildPackage {
   version = "ci";
   src = builtins.filterSource (p: t: lib.cleanSourceFilter p t && baseNameOf p != "target") ./.;
   buildInputs = [
+      pkgs.clang
+      pkgs.git
       pkgs.openssl
       pkgs.pkg-config
       pkgs.perl
   ];
-gitSubmodules = true;
-  
+  gitSubmodules = true;
+  LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
 }

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1655078190,
-        "narHash": "sha256-ZFzXWRyN/YpvkrOKH+LHHX9SvfB7jLFNHt6yUqlZPbM=",
+        "lastModified": 1656602417,
+        "narHash": "sha256-PJx1iVc3Gwd9Hh00OxCVFdmn9Exzo7Kd/5U6xysIl+4=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "4a3f1394b2bc7f735f43998fc15c94579ea1d13c",
+        "rev": "c850d8c9352ae655b3ba1802889c9d80ae9b7ea6",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {
@@ -70,11 +70,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655456688,
-        "narHash": "sha256-j2trI5gv2fnHdfUQFBy957avCPxxzCqE8R+TOYHPSRE=",
+        "lastModified": 1657123678,
+        "narHash": "sha256-cowVkScfUPlbBXUp08MeVk/wgm9E1zp1uC+9no2hZYw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d17a56d90ecbd1b8fc908d49598fb854ef188461",
+        "rev": "316b762afdb9e142a803f29c49a88b4a47db80ee",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,14 +19,18 @@
           src = ./.;
 
           buildInputs = with pkgs; [
+            clang
             openssl
             pkg-config
             perl
           ];
 
           nativeBuildInputs = with pkgs; [
+            clang
             pkg-config
           ];
+
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
         };
 
         cargoArtifacts = craneLib.buildDepsOnly (commonArgs // {

--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -16,9 +16,10 @@ futures = "0.3.21"
 hex = "0.4.3"
 lightning-invoice = "0.17.0"
 minimint = { path = "../minimint" }
-minimint-api = { path = "../minimint-api" }
+minimint-api = { path = "../minimint-api", features = ["rocksdb"] }
 mint-client = { path = "../client/client-lib" }
 rand = "0.6"
+rocksdb = { git = "https://github.com/fedimint/rust-rocksdb", branch = "minimint" }
 secp256k1 = "0.22.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.61"

--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -86,10 +86,8 @@ async fn initialize_gateway(
     // Run the gateway
     let db_path = workdir.join("gateway.db");
     let gw_client_cfg: GatewayClientConfig = load_from_file(&cfg_path);
-    let db = sled::open(&db_path)
-        .unwrap()
-        .open_tree("mint-client")
-        .unwrap();
+    let db: rocksdb::OptimisticTransactionDB<rocksdb::SingleThreaded> =
+        rocksdb::OptimisticTransactionDB::open_default(&db_path).unwrap();
     let ctx = secp256k1::Secp256k1::new();
     let federation_client = Arc::new(Client::new(gw_client_cfg, Box::new(db), ctx));
     let ln_client = Box::new(Mutex::new(ln_client));

--- a/minimint-api/Cargo.toml
+++ b/minimint-api/Cargo.toml
@@ -17,6 +17,7 @@ minimint-derive = { path = "../minimint-derive" }
 rand = "0.6.0"
 rand07 = { version = "0.7", package = "rand" }
 secp256k1-zkp = { version = "0.6.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }
+rocksdb = { git = "https://github.com/fedimint/rust-rocksdb", branch = "minimint", optional = true }
 serde = { version = "1.0.118", features = [ "derive" ] }
 serde_json = "1.0.79"
 sled = "0.34"

--- a/minimint-api/src/db/mem_impl.rs
+++ b/minimint-api/src/db/mem_impl.rs
@@ -40,7 +40,7 @@ impl Database for MemDatabase {
         Ok(self.data.lock().unwrap().remove(key))
     }
 
-    fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter {
+    fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter<'_> {
         let mut data = self
             .data
             .lock()

--- a/minimint-api/src/db/mod.rs
+++ b/minimint-api/src/db/mod.rs
@@ -32,7 +32,7 @@ pub trait DatabaseValue: Sized + SerializableDatabaseValue {
     fn from_bytes(data: &[u8]) -> Result<Self, DecodingError>;
 }
 
-pub type PrefixIter = Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>)>> + Send>;
+pub type PrefixIter<'a> = Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>)>> + Send + 'a>;
 
 pub trait Database: Send + Sync {
     fn raw_insert_entry(&self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>>;
@@ -41,7 +41,7 @@ pub trait Database: Send + Sync {
 
     fn raw_remove_entry(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 
-    fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter;
+    fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter<'_>;
 
     fn raw_apply_batch(&self, batch: DbBatch) -> Result<()>;
 }
@@ -103,7 +103,7 @@ impl<'a> dyn Database + 'a {
     pub fn find_by_prefix<KP>(
         &self,
         key_prefix: &KP,
-    ) -> impl Iterator<Item = Result<(KP::Key, KP::Value)>>
+    ) -> impl Iterator<Item = Result<(KP::Key, KP::Value)>> + '_
     where
         KP: DatabaseKeyPrefix + DatabaseKeyPrefixConst,
     {

--- a/minimint-api/src/db/mod.rs
+++ b/minimint-api/src/db/mod.rs
@@ -8,6 +8,8 @@ use tracing::trace;
 
 pub mod batch;
 pub mod mem_impl;
+#[cfg(feature = "rocksdb")]
+mod rocksdb_impl;
 pub mod sled_impl;
 
 pub trait DatabaseKeyPrefixConst {

--- a/minimint-api/src/db/rocksdb_impl.rs
+++ b/minimint-api/src/db/rocksdb_impl.rs
@@ -1,0 +1,91 @@
+use super::batch::{BatchItem, DbBatch};
+use super::Database;
+use crate::db::PrefixIter;
+use anyhow::Result;
+use tracing::{error, trace};
+
+impl Database for rocksdb::OptimisticTransactionDB {
+    fn raw_insert_entry(&self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
+        let val = self.get(key).unwrap();
+        self.put(key, value)?;
+        Ok(val)
+    }
+
+    fn raw_get_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        Ok(self.get(key)?)
+    }
+
+    fn raw_remove_entry(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        let val = self.get(key).unwrap();
+        self.delete(key)?;
+        Ok(val)
+    }
+
+    fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter<'_> {
+        let prefix = key_prefix.to_vec();
+        Box::new(
+            self.prefix_iterator(prefix.clone())
+                .map_while(move |res| res.0.starts_with(&prefix).then(|| res))
+                .map(|(key_bytes, value_bytes)| (key_bytes.to_vec(), value_bytes.to_vec()))
+                .map(Ok),
+        )
+    }
+
+    fn raw_apply_batch(&self, batch: DbBatch) -> Result<()> {
+        let batch: Vec<_> = batch.into();
+        let tx = self.transaction();
+
+        for change in batch.iter() {
+            match change {
+                BatchItem::InsertNewElement(element) => {
+                    if tx.get(element.key.to_bytes()).unwrap().is_some() {
+                        tx.put(element.key.to_bytes(), element.value.to_bytes())?;
+                        error!("Database replaced element! This should not happen!");
+                        trace!("Problematic key: {:?}", element.key);
+                    } else {
+                        tx.put(element.key.to_bytes(), element.value.to_bytes())?;
+                    }
+                }
+                BatchItem::InsertElement(element) => {
+                    tx.put(element.key.to_bytes(), element.value.to_bytes())?;
+                }
+                BatchItem::DeleteElement(key) => {
+                    if tx.get(key.to_bytes()).unwrap().is_none() {
+                        tx.delete(key.to_bytes())?;
+                        error!("Database deleted absent element! This should not happen!");
+                        trace!("Problematic key: {:?}", key);
+                    } else {
+                        tx.delete(key.to_bytes())?;
+                    }
+                }
+                BatchItem::MaybeDeleteElement(key) => {
+                    tx.delete(key.to_bytes())?;
+                }
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    #[test_log::test]
+    fn test_basic_rw() {
+        use rocksdb::{OptimisticTransactionDB, Options, SingleThreaded};
+
+        let path = tempfile::Builder::new()
+            .prefix("fcb-rocksdb-test")
+            .tempdir()
+            .unwrap();
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+
+        let db: OptimisticTransactionDB<SingleThreaded> =
+            OptimisticTransactionDB::open_default(path).unwrap();
+
+        crate::db::tests::test_db_impl(Arc::new(db));
+    }
+}

--- a/minimint-api/src/db/sled_impl.rs
+++ b/minimint-api/src/db/sled_impl.rs
@@ -25,7 +25,7 @@ impl Database for sled::Tree {
             .map(|bytes| bytes.to_vec()))
     }
 
-    fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter {
+    fn raw_find_by_prefix(&self, key_prefix: &[u8]) -> PrefixIter<'_> {
         Box::new(self.scan_prefix(key_prefix).map(|res| {
             res.map(|(key_bytes, value_bytes)| (key_bytes.to_vec(), value_bytes.to_vec()))
                 .map_err(anyhow::Error::from)

--- a/minimint/Cargo.toml
+++ b/minimint/Cargo.toml
@@ -21,7 +21,7 @@ hbbft = { git = "https://github.com/fedimint/hbbft" }
 hex = "0.4.2"
 itertools = "0.10.0"
 jsonrpsee = { version = "0.14.0", features = ["ws-server"] }
-minimint-api = { path = "../minimint-api" }
+minimint-api = { path = "../minimint-api", features = ["rocksdb"] }
 minimint-core = { path = "../minimint-core" }
 minimint-derive = { path = "../minimint-derive" }
 minimint-wallet = { path = "../modules/minimint-wallet", features = ["native"] }
@@ -31,6 +31,7 @@ rand = "0.6.5"
 rayon = "1.5.0"
 rcgen = "0.9.2"
 secp256k1-zkp = { version = "0.6.0", features = [ "global-context", "bitcoin_hashes" ] }
+rocksdb = { git = "https://github.com/fedimint/rust-rocksdb", branch = "minimint"}
 serde = { version = "1.0.118", features = [ "derive" ] }
 serde_json = "1.0.61"
 sha3 = "0.9.1"

--- a/minimint/src/lib.rs
+++ b/minimint/src/lib.rs
@@ -68,7 +68,7 @@ impl MinimintServer {
 
         Self::new_with(
             cfg.clone(),
-            Arc::new(sled::open(&db_path).unwrap().open_tree("mint").unwrap()),
+            Arc::new(rocksdb::OptimisticTransactionDB::open_default(&db_path).unwrap()),
             bitcoincore_rpc::bitcoind_gen(cfg.wallet.clone()),
             connector,
         )

--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,7 @@ in
 pkgs.mkShell {
   packages = with pkgs; [
     bc
+    clang
     openssl
     pkg-config
     perl
@@ -42,5 +43,6 @@ pkgs.mkShell {
     # filter out global cargo installation so it doesn't interfere
     PATH="$(echo $PATH | sed "s/:[^:]*\.cargo[^:]*//g")"
   '';
+  LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
 }
 


### PR DESCRIPTION
TODO:
- Fix the lifetimes for the raw prefix search
- Change the API and Database trait to support self referencing transactions 
- Use native rocksdb column families instead of prefixing (e.g. collecting signature shares for a given token and deleting the column later)
- Perhaps create inherited traits for basic database -> transactional database -> transactional + column family database
- Crate generic trait for expected "transaction" behaviors and functionality
- Get rid of sled_impl and replace all references
- Remove Batch.rs  
- Improve UT and add coverage for all expected trait functionality
Note: transactions are soon to be merged into rust-rocksdb we are simply waiting on a couple changes for the next rocksdb you can track the issue here https://github.com/rust-rocksdb/rust-rocksdb/pull/565/files#. Obviously we will want to change to master as soon as possible.