### PR TITLE
"retryable" error type for preimages that aren't decrypted yet

### DIFF
--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -65,9 +65,7 @@ impl<'a> dyn FederationApi + 'a {
             loop {
                 match self.fetch_output_outcome(outpoint).await {
                     Ok(t) => return Ok(t),
-                    Err(e) if e.is_retryable_fetch_coins() => {
-                        minimint_api::task::sleep(interval).await
-                    }
+                    Err(e) if e.is_retryable() => minimint_api::task::sleep(interval).await,
                     Err(e) => return Err(e),
                 }
             }
@@ -106,7 +104,7 @@ pub enum ApiError {
 impl ApiError {
     /// Returns `true` if the error means that the queried coin output isn't ready yet but might
     /// become ready later.
-    pub fn is_retryable_fetch_coins(&self) -> bool {
+    pub fn is_retryable(&self) -> bool {
         match self {
             ApiError::HttpError(e) => e.status() == Some(StatusCode::NOT_FOUND),
             _ => false,

--- a/client/client-lib/src/clients/gateway.rs
+++ b/client/client-lib/src/clients/gateway.rs
@@ -346,7 +346,7 @@ impl GatewayClient {
     }
 
     /// Tries to fetch e-cash tokens from a certain out point. An error may just mean having queried
-    /// the federation too early. Use [`MintClientError::is_retryable_fetch_coins`] to determine
+    /// the federation too early. Use [`MintClientError::is_retryable`] to determine
     /// if the operation should be retried at a later time.
     pub async fn fetch_coins<'a>(
         &self,

--- a/client/client-lib/src/clients/user.rs
+++ b/client/client-lib/src/clients/user.rs
@@ -248,7 +248,7 @@ impl UserClient {
     }
 
     /// Tries to fetch e-cash tokens from a certain out point. An error may just mean having queried
-    /// the federation too early. Use [`MintClientError::is_retryable_fetch_coins`] to determine
+    /// the federation too early. Use [`MintClientError::is_retryable`] to determine
     /// if the operation should be retried at a later time.
     pub async fn fetch_coins<'a>(&self, outpoint: OutPoint) -> Result<(), MintClientError> {
         let mut batch = DbBatch::new();

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -400,8 +400,7 @@ pub enum MintClientError {
 }
 
 impl MintClientError {
-    /// Returns `true` if the error means that the queried coin output isn't ready yet but might
-    /// become ready later.
+    /// Returns `true` if queried outpoint isn't ready yet but may become ready later
     pub fn is_retryable(&self) -> bool {
         match self {
             MintClientError::ApiError(e) => e.is_retryable(),

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -254,7 +254,7 @@ impl<'c> MintClient<'c> {
                         break;
                     }
                     // TODO: make mint error more expressive (currently any HTTP error) and maybe use custom return type instead of error for retrying
-                    Err(e) if e.is_retryable_fetch_coins() => {
+                    Err(e) if e.is_retryable() => {
                         trace!("Mint returned retryable error: {:?}", e);
                         minimint_api::task::sleep(Duration::from_secs(1)).await
                     }
@@ -402,9 +402,9 @@ pub enum MintClientError {
 impl MintClientError {
     /// Returns `true` if the error means that the queried coin output isn't ready yet but might
     /// become ready later.
-    pub fn is_retryable_fetch_coins(&self) -> bool {
+    pub fn is_retryable(&self) -> bool {
         match self {
-            MintClientError::ApiError(e) => e.is_retryable_fetch_coins(),
+            MintClientError::ApiError(e) => e.is_retryable(),
             MintClientError::OutputNotReadyYet(_) => true,
             _ => false,
         }

--- a/minimint-core/src/lib.rs
+++ b/minimint-core/src/lib.rs
@@ -1,3 +1,5 @@
+use thiserror::Error;
+
 pub mod modules {
     pub use minimint_ln as ln;
     pub use minimint_mint as mint;
@@ -10,3 +12,18 @@ pub mod transaction;
 pub mod config;
 
 pub mod outcome;
+
+#[derive(Debug, Error)]
+pub enum CoreError {
+    #[error("Mismatching outcome variant: expected {0}, got {1}")]
+    MismatchingVariant(&'static str, &'static str),
+    #[error("Pending preimage decryption")]
+    PendingPreimage,
+}
+
+impl CoreError {
+    /// Returns `true` if queried outpoint isn't ready yet but may become ready later
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, CoreError::PendingPreimage)
+    }
+}


### PR DESCRIPTION
#146 had a little bug where [this line](https://github.com/fedimint/minimint/blob/386706597716319081609bcccbe22232c9d3111a/client/client-lib/src/clients/gateway.rs#L316) would just fail with a `MismatchingVariant` error when the outpoint contained `DecryptedPreimage::Pending`. The integration tests didn't catch this because they just skipped the "pending" state, but I noticed it testing the actual core-lightning plugin in `integrationtest.sh`.

Renamed all `is_retryable_fetch_coins` to `is_retryable` because we're not just re-fetching coins anymore ...