### PR TITLE
fix clippy -- -D warnings 'error: temporary with significant drop in for loop'

### DIFF
--- a/minimint-api/src/db/mem_impl.rs
+++ b/minimint-api/src/db/mem_impl.rs
@@ -20,7 +20,8 @@ impl MemDatabase {
     }
 
     pub fn dump_db(&self) {
-        for (key, value) in self.data.lock().unwrap().iter() {
+        let data = self.data.lock().unwrap();
+        for (key, value) in data.iter() {
             eprintln!("{}: {}", hex::encode(key), hex::encode(value));
         }
     }


### PR DESCRIPTION
noticed when running: `bash ./scripts/final-checks.sh`
https://rust-lang.github.io/rust-clippy/master/index.html#significant_drop_in_scrutinee
Even though `#[allow(clippy::has_significant_drop)]` would also solve it, I prefer just initializing data before the loop.