### PR TITLE
Reduce log level in background_fetch to "debug"

### DIFF
--- a/ln-gateway/src/lib.rs
+++ b/ln-gateway/src/lib.rs
@@ -165,7 +165,7 @@ async fn background_fetch(federation_client: Arc<GatewayClient>, _ln_client: Arc
                 let federation_client = federation_client.clone();
                 async move {
                     if let Err(e) = federation_client.fetch_coins(out_point).await {
-                        error!(error = %e, "Fetching coins failed");
+                        debug!(error = %e, "Fetching coins failed");
                     }
                 }
             })


### PR DESCRIPTION
This thing makes too much noise! (image from integration tests)

<img width="1492" alt="image" src="https://user-images.githubusercontent.com/4335621/175793029-7987a048-9b58-4560-9d95-27f9e0d65431.png">
