### PR TITLE
Clientd rest api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_hashes",
  "clap",
+ "lightning-invoice",
  "minimint-api",
  "minimint-core",
  "mint-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,7 @@ dependencies = [
 name = "clientd"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
  "bitcoin",
  "bitcoin_hashes",
@@ -1565,6 +1566,19 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -2874,23 +2888,45 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.9",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rest-client-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.13.0",
+ "bitcoin",
+ "clap",
+ "clientd",
+ "lightning-invoice",
+ "minimint-api",
+ "minimint-core",
+ "mint-client",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -3622,6 +3658,16 @@ dependencies = [
  "proc-macro2 1.0.40",
  "quote 1.0.20",
  "syn 1.0.98",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "minimint-core",
  "mint-client",
  "rand 0.6.5",
+ "reqwest",
  "serde",
  "serde_json",
  "sled",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,6 @@ dependencies = [
 name = "clientd"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "axum",
  "bitcoin",
  "bitcoin_hashes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,10 +690,12 @@ name = "clientd"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "bitcoin",
  "clap",
  "minimint-api",
  "minimint-core",
  "mint-client",
+ "rand 0.6.5",
  "serde",
  "sled",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,8 +119,8 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
- "quote 1.0.18",
- "syn 1.0.95",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -160,14 +160,14 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290043c9a95b05d45e952fb6383c67bcb61471f60cfa21e890dba6654234f43"
+checksum = "5262ed948da60dd8956c6c5aca4d4163593dddb7b32d73267c93dab7b2e98940"
 dependencies = [
  "async-channel",
  "async-executor",
  "async-io",
- "async-mutex",
+ "async-lock",
  "blocking",
  "futures-lite",
  "num_cpus",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
+checksum = "e5e18f61464ae81cde0a23e713ae8fd299580c54d697a35820cfd0625b8b0e07"
 dependencies = [
  "concurrent-queue",
  "futures-lite",
@@ -215,15 +215,6 @@ name = "async-lock"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
 ]
@@ -282,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
  "async-attributes",
  "async-channel",
@@ -301,7 +292,6 @@ dependencies = [
  "kv-log-macro",
  "log",
  "memchr",
- "num_cpus",
  "once_cell",
  "pin-project-lite 0.2.9",
  "pin-utils",
@@ -317,13 +307,13 @@ checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -357,6 +347,51 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d590cacd53140ff87cc2e192eb22fc3dc23c5b3f93b0d4f020677f98e8c629"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite 0.2.9",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4d047478b986f14a13edad31a009e2e05cb241f9805d0d75e4cba4e129ad4d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+]
 
 [[package]]
 name = "backtrace"
@@ -548,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"
@@ -613,16 +648,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -630,24 +665,42 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "clientd"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "clap",
+ "minimint-api",
+ "minimint-core",
+ "mint-client",
+ "serde",
+ "sled",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -777,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -798,26 +851,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "8ff1f980957787286a554052d03c7aee98d99cc32e09f6d45f0a814133c87978"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -852,8 +905,8 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
- "quote 1.0.18",
- "syn 1.0.95",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -921,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad132dd8d0d0b546348d7d86cb3191aad14b34e5f979781fc005c80d4ac67ffd"
+checksum = "81d013529d5574a60caeda29e179e695125448e5de52e3874f7b4c1d7360e18e"
 dependencies = [
  "serde",
 ]
@@ -971,9 +1024,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
  "synstructure",
 ]
 
@@ -1033,9 +1086,9 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1160,9 +1213,9 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1227,14 +1280,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1304,15 +1357,15 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.3",
  "tracing",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "hbbft"
@@ -1403,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
@@ -1414,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
@@ -1425,15 +1478,21 @@ dependencies = [
 
 [[package]]
 name = "http-client"
-version = "6.5.2"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e023af341b797ce2c039f7c6e1d347b68d0f7fd0bc7ac234fe69cfadcca1f89a"
+checksum = "1947510dc91e2bf586ea5ffb412caad7673264e14bb39fb9078da114a94ce1a5"
 dependencies = [
  "async-trait",
  "cfg-if 1.0.0",
  "http-types",
  "log",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "http-types"
@@ -1480,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.18"
+version = "0.14.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26ae0a80afebe130861d90abf98e3814a4f28a4c6ffeb5ab8ebb2be311e0ef2"
+checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1521,9 +1580,9 @@ checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "6c6392766afd7964e2531940894cffe4bd8d7d17dbc3c1c4857040fd4b33bdb3"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown",
@@ -1600,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "kv-log-macro"
@@ -1724,6 +1783,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,7 +1866,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_hashes",
  "futures",
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
  "gloo-timers",
  "hex",
  "http-types",
@@ -1851,9 +1916,9 @@ name = "minimint-derive"
 version = "0.1.0"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1964,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
  "adler",
 ]
@@ -2021,9 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -2100,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b10983b38c53aebdf33f542c6275b0f58a238129d00c4ae0e6fb59738d783ca"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "opaque-debug"
@@ -2131,9 +2196,9 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -2153,9 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.73"
+version = "0.9.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
+checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
 dependencies = [
  "autocfg 1.1.0",
  "cc",
@@ -2272,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
  "parking_lot_core 0.9.3",
@@ -2328,9 +2393,9 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -2394,9 +2459,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
  "version_check",
 ]
 
@@ -2406,8 +2471,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
  "version_check",
 ]
 
@@ -2428,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
@@ -2458,11 +2523,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
- "proc-macro2 1.0.39",
+ "proc-macro2 1.0.40",
 ]
 
 [[package]]
@@ -2606,7 +2671,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.6",
+ "getrandom 0.2.7",
 ]
 
 [[package]]
@@ -2743,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "reed-solomon-erasure"
-version = "5.0.2"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521342afeca28aec72cefa21941c640549a8d61d9dd13710da63a1c975b78dba"
+checksum = "c2fe31452b684b8b33f65f8730c8b8812c3f5a0bb8a096934717edb1ac488641"
 dependencies = [
  "libm",
  "parking_lot 0.11.2",
@@ -2755,9 +2820,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2775,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
@@ -2790,9 +2855,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -2814,6 +2879,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2956,9 +3022,9 @@ version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -3154,11 +3220,11 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
  "serde",
  "serde_derive",
- "syn 1.0.95",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -3168,13 +3234,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
 dependencies = [
  "base-x",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
  "serde",
  "serde_derive",
  "serde_json",
  "sha1",
- "syn 1.0.95",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -3228,14 +3294,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
 name = "synom"
@@ -3252,9 +3324,9 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
  "unicode-xid 0.2.3",
 ]
 
@@ -3309,9 +3381,9 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4235dbf7ea878b3ef12dea20a59c134b405a66aafc4fc2c7b9935916e289e735"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -3335,9 +3407,9 @@ version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -3476,10 +3548,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
  "standback",
- "syn 1.0.95",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -3527,7 +3599,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot 0.12.1",
  "pin-project-lite 0.2.9",
  "signal-hook-registry",
  "socket2",
@@ -3537,13 +3609,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -3562,9 +3634,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3575,18 +3647,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-service"
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite 0.2.9",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite 0.2.9",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if 1.0.0",
+ "log",
  "pin-project-lite 0.2.9",
  "tracing-attributes",
  "tracing-core",
@@ -3598,18 +3713,18 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 
@@ -3676,9 +3791,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
@@ -3762,10 +3877,10 @@ dependencies = [
  "if_chain",
  "lazy_static",
  "proc-macro-error",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
  "regex",
- "syn 1.0.95",
+ "syn 1.0.98",
  "validator_types",
 ]
 
@@ -3862,9 +3977,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -3886,7 +4001,7 @@ version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
- "quote 1.0.18",
+ "quote 1.0.20",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3896,9 +4011,9 @@ version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.95",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3911,9 +4026,9 @@ checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,14 +689,17 @@ dependencies = [
 name = "clientd"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "bitcoin",
+ "bitcoin_hashes",
  "clap",
  "minimint-api",
  "minimint-core",
  "mint-client",
  "rand 0.6.5",
  "serde",
+ "serde_json",
  "sled",
  "tokio",
  "tower",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "minimint-derive",
     "minimint-api",
     "client/cli",
+    "client/rest-client-cli",
     "client/clientd",
     "client/client-lib",
     "modules/minimint-mint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "minimint-derive",
     "minimint-api",
     "client/cli",
+    "client/clientd",
     "client/client-lib",
     "modules/minimint-mint",
     "modules/minimint-ln",

--- a/client/client-lib/src/clients/gateway.rs
+++ b/client/client-lib/src/clients/gateway.rs
@@ -342,7 +342,7 @@ impl GatewayClient {
     }
 
     pub fn list_fetchable_coins(&self) -> Vec<OutPoint> {
-        self.mint_client().list_active_issuances()
+        self.mint_client().list_active_issuances().0
     }
 
     /// Tries to fetch e-cash tokens from a certain out point. An error may just mean having queried

--- a/client/client-lib/src/clients/user.rs
+++ b/client/client-lib/src/clients/user.rs
@@ -23,6 +23,7 @@ use minimint_core::modules::ln::ContractOrOfferOutput;
 use minimint_core::modules::mint::tiered::coins::Coins;
 use minimint_core::modules::mint::BlindToken;
 use minimint_core::modules::wallet::txoproof::TxOutProof;
+use minimint_core::outcome::TransactionStatus;
 use minimint_core::transaction::{Input, Output, TransactionItem};
 use rand::{CryptoRng, RngCore};
 use secp256k1_zkp::{All, Secp256k1};
@@ -400,6 +401,29 @@ impl UserClient {
 
     pub fn fetch_active_issuances(&self) -> Vec<CoinFinalizationData> {
         self.mint_client().list_active_issuances().1
+    }
+
+    /// Fetches the TransactionStatus for a txid
+    /// Polling should *only* be set to true if it is anticipated that the txid is valid but has not yet been processed
+    pub async fn fetch_tx_outcome(
+        &self,
+        tx: TransactionId,
+        polling: bool,
+    ) -> Result<TransactionStatus, ClientError> {
+        //did not choose to use the MintClientError is_retryable logic because the 404 error should normaly
+        //not be retryable just in this specific case...
+        let status;
+        loop {
+            match self.context.api.fetch_tx_outcome(tx).await {
+                Ok(s) => {
+                    status = s;
+                    break;
+                }
+                Err(_e) if polling => minimint_api::task::sleep(Duration::from_secs(1)).await,
+                Err(e) => return Err(ClientError::MintApiError(e)),
+            }
+        }
+        Ok(status)
     }
 }
 

--- a/client/client-lib/src/clients/user.rs
+++ b/client/client-lib/src/clients/user.rs
@@ -2,7 +2,7 @@ use crate::api::{ApiError, FederationApi};
 use crate::clients::transaction::TransactionBuilder;
 use crate::ln::gateway::LightningGateway;
 use crate::ln::{LnClient, LnClientError};
-use crate::mint::{MintClient, MintClientError, SpendableCoin};
+use crate::mint::{CoinFinalizationData, MintClient, MintClientError, SpendableCoin};
 use crate::wallet::{WalletClient, WalletClientError};
 use crate::{api, OwnedClientContext};
 use bitcoin::schnorr::KeyPair;
@@ -396,6 +396,10 @@ impl UserClient {
         tx.input(&mut vec![keypair], Input::LN(contract.claim()));
         self.submit_tx_with_change(tx, DbBatch::new(), &mut rng)
             .await
+    }
+
+    pub fn fetch_active_issuances(&self) -> Vec<CoinFinalizationData> {
+        self.mint_client().list_active_issuances().1
     }
 }
 

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -227,12 +227,15 @@ impl<'c> MintClient<'c> {
         Ok(())
     }
 
-    pub fn list_active_issuances(&self) -> Vec<OutPoint> {
+    pub fn list_active_issuances(&self) -> (Vec<OutPoint>, Vec<CoinFinalizationData>) {
         self.context
             .db
             .find_by_prefix(&OutputFinalizationKeyPrefix)
-            .map(|res| res.expect("DB error").0 .0)
-            .collect()
+            .map(|res| {
+                let res = res.expect("DB error");
+                (res.0 .0, res.1)
+            })
+            .unzip()
     }
 
     // FIXME: remove
@@ -335,6 +338,9 @@ impl CoinFinalizationData {
 
     pub fn coin_count(&self) -> usize {
         self.coins.coins.values().map(|v| v.len()).sum()
+    }
+    pub fn coin_amount(&self) -> Amount {
+        self.coins.amount()
     }
 }
 

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.56"
 mint-client = { path = "../client-lib" }
 minimint-api = { path = "../../minimint-api" }
 minimint-core = { path = "../../minimint-core" }

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -6,12 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.56"
 mint-client = { path = "../client-lib" }
 minimint-api = { path = "../../minimint-api" }
 minimint-core = { path = "../../minimint-core" }
+bitcoin_hashes = "0.10.0"
 sled = "0.34.6"
 tokio = { version = "1.19.2", features = ["full"] }
 serde = { version = "1.0.118", features = [ "derive" ] }
+serde_json = { version = "1"}
 tracing ="0.1.22"
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }
 clap = { version = "3.1.18", features = ["derive"] }
@@ -19,4 +22,4 @@ axum = "0.5.9"
 tower = { version = "0.4.13"}
 tower-http = { version = "0.3.4", features = [ "trace" ] }
 rand = "0.6.5"
-bitcoin = "0.27.0"
+bitcoin = { version = "0.27.0", features = ["serde"] }

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.58"
 mint-client = { path = "../client-lib" }
 minimint-api = { path = "../../minimint-api" }
 minimint-core = { path = "../../minimint-core" }

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -22,5 +22,6 @@ clap = { version = "3.1.18", features = ["derive"] }
 axum = "0.5.9"
 tower = { version = "0.4.13"}
 tower-http = { version = "0.3.4", features = [ "trace" ] }
+reqwest = { version = "0.11.0", features = [ "json" ], default-features = false }
 rand = "0.6.5"
 bitcoin = { version = "0.27.0", features = ["serde"] }

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -18,3 +18,5 @@ clap = { version = "3.1.18", features = ["derive"] }
 axum = "0.5.9"
 tower = { version = "0.4.13"}
 tower-http = { version = "0.3.4", features = [ "trace" ] }
+rand = "0.6.5"
+bitcoin = "0.27.0"

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -11,6 +11,7 @@ mint-client = { path = "../client-lib" }
 minimint-api = { path = "../../minimint-api" }
 minimint-core = { path = "../../minimint-core" }
 bitcoin_hashes = "0.10.0"
+lightning-invoice = "0.14.0"
 sled = "0.34.6"
 tokio = { version = "1.19.2", features = ["full"] }
 serde = { version = "1.0.118", features = [ "derive" ] }

--- a/client/clientd/Cargo.toml
+++ b/client/clientd/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "clientd"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+mint-client = { path = "../client-lib" }
+minimint-api = { path = "../../minimint-api" }
+minimint-core = { path = "../../minimint-core" }
+sled = "0.34.6"
+tokio = { version = "1.19.2", features = ["full"] }
+serde = { version = "1.0.118", features = [ "derive" ] }
+tracing ="0.1.22"
+tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }
+clap = { version = "3.1.18", features = ["derive"] }
+axum = "0.5.9"
+tower = { version = "0.4.13"}
+tower-http = { version = "0.3.4", features = [ "trace" ] }

--- a/client/clientd/src/lib.rs
+++ b/client/clientd/src/lib.rs
@@ -9,10 +9,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
+use crate::payload::PeginPayload;
 use minimint_core::modules::wallet::txoproof::TxOutProof;
 use mint_client::utils::from_hex;
-
-use crate::PeginPayload;
 
 pub mod payload {
     use bitcoin::Transaction;
@@ -38,12 +37,11 @@ pub mod payload {
 pub mod responses {
     use serde::Serialize;
 
+    use crate::CoinsByTier;
     use minimint_api::{Amount, OutPoint, TransactionId};
     use minimint_core::modules::mint::tiered::coins::Coins;
     use minimint_core::outcome::TransactionStatus;
     use mint_client::mint::{CoinFinalizationData, SpendableCoin};
-
-    use crate::utils::CoinsByTier;
 
     #[derive(Serialize)]
     pub enum RpcResult {
@@ -234,7 +232,7 @@ where
         }
         let encoded: PeginPayloadEncoded = Json::from_request(req).await?.0;
         let transaction = from_hex(&encoded.transaction).unwrap(); //FIXME: this is bad
-        let decoded = super::PeginPayload {
+        let decoded = PeginPayload {
             txout_proof: encoded.txout_proof,
             transaction,
         };

--- a/client/clientd/src/lib.rs
+++ b/client/clientd/src/lib.rs
@@ -25,6 +25,13 @@ pub mod payload {
         pub transaction: Transaction,
     }
 
+    #[derive(Deserialize, Clone, Debug)]
+    pub struct PegoutPayload {
+        pub address: bitcoin::Address,
+        #[serde(with = "bitcoin::util::amount::serde::as_sat")]
+        pub amount: bitcoin::Amount,
+    }
+
     //TODO: remove this and also super::serde_invoice, when lightning_invoice "serde" feature becomes available
     #[derive(Deserialize)]
     #[serde(transparent)]

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -12,10 +12,14 @@ use bitcoin_hashes::hex::ToHex;
 use clap::Parser;
 use minimint_api::Amount;
 use minimint_core::config::load_from_file;
+use minimint_core::modules::mint::tiered::coins::Coins;
+use mint_client::mint::SpendableCoin;
 use mint_client::{ClientAndGatewayConfig, UserClient};
 use rand::rngs::OsRng;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::Sender;
 use tower::ServiceBuilder;
 use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer};
 use tracing::{info, Level};
@@ -26,7 +30,8 @@ struct Config {
     workdir: PathBuf,
 }
 struct State {
-    client: UserClient,
+    client: Arc<UserClient>,
+    fetch_tx: Sender<()>,
     rng: OsRng,
 }
 #[tokio::main]
@@ -46,10 +51,19 @@ async fn main() {
         .open_tree("mint-client")
         .unwrap();
 
-    let client = UserClient::new(cfg.client, Box::new(db), Default::default());
+    let client = Arc::new(UserClient::new(
+        cfg.client,
+        Box::new(db),
+        Default::default(),
+    ));
+    let (tx, mut rx) = mpsc::channel(1024);
     let rng = OsRng::new().unwrap();
 
-    let shared_state = Arc::new(State { client, rng });
+    let shared_state = Arc::new(State {
+        client: Arc::clone(&client),
+        fetch_tx: tx,
+        rng,
+    });
 
     let app = Router::new()
         .route("/getInfo", post(info))
@@ -57,6 +71,7 @@ async fn main() {
         .route("/getPeginAdress", post(pegin_address))
         .route("/pegin", post(pegin))
         .route("/spend", post(spend))
+        .route("/reissue", post(reissue))
         .layer(
             ServiceBuilder::new()
                 .layer(
@@ -67,6 +82,13 @@ async fn main() {
                 )
                 .layer(Extension(shared_state)),
         );
+
+    let fetch_client = Arc::clone(&client);
+    tokio::spawn(async move {
+        while rx.recv().await.is_some() {
+            fetch(Arc::clone(&fetch_client)).await;
+        }
+    });
 
     Server::bind(&"127.0.0.1:8081".parse().unwrap())
         .serve(app.into_make_service())
@@ -121,4 +143,22 @@ async fn spend(
 
     let spending_coins = client.select_and_spend_coins(amount).unwrap(); //TODO: handle unwrap()
     Json(SpendResponse::new(spending_coins))
+}
+
+async fn reissue(Extension(state): Extension<Arc<State>>, payload: Json<Coins<SpendableCoin>>) {
+    let state = Arc::clone(&state);
+    let coins = payload.0;
+    tokio::spawn(async move {
+        let client = &state.client;
+        let fetch_tx = state.fetch_tx.clone();
+        let mut rng = state.rng.clone();
+        //TODO: log what happens here and handle unwraps()
+        client.reissue(coins, &mut rng).await.unwrap();
+        fetch_tx.send(()).await.unwrap();
+    });
+}
+
+async fn fetch(client: Arc<UserClient>) {
+    //TODO: log txid or error (handle unwrap)
+    client.fetch_all_coins().await.unwrap();
 }

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -212,9 +212,13 @@ async fn lnpay(
 async fn fetch(client: Arc<UserClient>, event_log: Arc<EventLog>) {
     match client.fetch_all_coins().await {
         Ok(txids) => {
-            event_log
-                .add(format!("successfully fetched: {:?}", txids))
-                .await
+            //if there are active issuances accumulated they'll all be fetched at once leaving active issuances empty
+            //this is not 'deterministic' though so it can happen that client.fetch_all_coins() will return ok but with an empty vec
+            if !txids.is_empty() {
+                event_log
+                    .add(format!("successfully fetched: {:?}", txids))
+                    .await
+            }
         }
         Err(e) => {
             event_log

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -1,9 +1,14 @@
 mod utils;
 
-use crate::utils::responses::{InfoResponse, PeginAddressResponse, PendingResponse};
+use crate::utils::payload::PeginPayload;
+use crate::utils::responses::{
+    InfoResponse, PegInOutResponse, PeginAddressResponse, PendingResponse,
+};
+use crate::utils::JsonDecodeTransaction;
 use axum::response::IntoResponse;
 use axum::routing::post;
 use axum::{Extension, Json, Router, Server};
+use bitcoin_hashes::hex::ToHex;
 use clap::Parser;
 use minimint_core::config::load_from_file;
 use mint_client::{ClientAndGatewayConfig, UserClient};
@@ -12,7 +17,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tower::ServiceBuilder;
 use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer};
-use tracing::Level;
+use tracing::{info, Level};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
@@ -44,10 +49,12 @@ async fn main() {
     let rng = OsRng::new().unwrap();
 
     let shared_state = Arc::new(State { client, rng });
+
     let app = Router::new()
         .route("/getInfo", post(info))
         .route("/getPending", post(pending))
         .route("/getPeginAdress", post(pegin_address))
+        .route("/pegin", post(pegin))
         .layer(
             ServiceBuilder::new()
                 .layer(
@@ -84,4 +91,20 @@ async fn pegin_address(Extension(state): Extension<Arc<State>>) -> impl IntoResp
     Json(PeginAddressResponse::new(
         client.get_new_pegin_address(&mut rng),
     ))
+}
+
+async fn pegin(
+    Extension(state): Extension<Arc<State>>,
+    payload: JsonDecodeTransaction,
+) -> impl IntoResponse {
+    let client = &state.client;
+    let mut rng = state.rng.clone();
+    let txout_proof = payload.0.txout_proof;
+    let transaction = payload.0.transaction;
+    let txid = client
+        .peg_in(txout_proof, transaction, &mut rng)
+        .await
+        .unwrap(); //TODO: handle unwrap()
+    info!("Started peg-in {}, result will be fetched", txid.to_hex());
+    Json(PegInOutResponse::new(txid))
 }

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -114,30 +114,34 @@ async fn main() {
 
 async fn info(Extension(state): Extension<Arc<State>>) -> impl IntoResponse {
     let client = &state.client;
-    Json(InfoResponse::new(
+    Json(RpcResult::Success(json!(InfoResponse::new(
         client.coins(),
         client.fetch_active_issuances(),
-    ))
+    ))))
 }
 
 async fn pending(Extension(state): Extension<Arc<State>>) -> impl IntoResponse {
     let client = &state.client;
-    Json(PendingResponse::new(client.fetch_active_issuances()))
+    Json(RpcResult::Success(json!(PendingResponse::new(
+        client.fetch_active_issuances()
+    ))))
 }
 
 async fn pegin_address(Extension(state): Extension<Arc<State>>) -> impl IntoResponse {
     let client = &state.client;
     let mut rng = state.rng.clone();
-    Json(PeginAddressResponse::new(
+    Json(RpcResult::Success(json!(PeginAddressResponse::new(
         client.get_new_pegin_address(&mut rng),
-    ))
+    ))))
 }
 
 async fn events(Extension(state): Extension<Arc<State>>, payload: Json<u64>) -> impl IntoResponse {
     let timestamp = payload.0;
     let event_log = &state.event_log;
     let queried_events = event_log.get(timestamp).await;
-    Json(EventsResponse::new(queried_events))
+    Json(RpcResult::Success(json!(EventsResponse::new(
+        queried_events
+    ))))
 }
 
 async fn pegin(

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -1,16 +1,14 @@
-mod utils;
-
-use crate::utils::payload::{LnPayPayload, PeginPayload};
-use crate::utils::responses::{
-    EventsResponse, InfoResponse, PegInOutResponse, PeginAddressResponse, PendingResponse,
-    ReissueResponse, RpcResult, SpendResponse,
-};
-use crate::utils::{Event, EventLog, JsonDecodeTransaction};
 use axum::response::IntoResponse;
 use axum::routing::post;
 use axum::{Extension, Json, Router, Server};
 use bitcoin_hashes::hex::ToHex;
 use clap::Parser;
+use clientd::payload::LnPayPayload;
+use clientd::responses::{
+    EventsResponse, InfoResponse, PegInOutResponse, PeginAddressResponse, PendingResponse,
+    ReissueResponse, RpcResult, SpendResponse,
+};
+use clientd::{Event, EventLog, JsonDecodeTransaction};
 use minimint_api::Amount;
 use minimint_core::config::load_from_file;
 use minimint_core::modules::mint::tiered::coins::Coins;

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -76,7 +76,7 @@ async fn main() {
 
 async fn info(Extension(state): Extension<Arc<State>>) -> impl IntoResponse {
     let client = &state.client;
-    Json(InfoResponse::build(
+    Json(InfoResponse::new(
         client.coins(),
         client.fetch_active_issuances(),
     ))

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -3,12 +3,12 @@ use axum::routing::post;
 use axum::{Extension, Json, Router, Server};
 use bitcoin_hashes::hex::ToHex;
 use clap::Parser;
-use clientd::payload::{LnPayPayload, PegoutPayload};
+use clientd::payload::{LnPayPayload, PeginPayload, PegoutPayload};
 use clientd::responses::{
     EventsResponse, InfoResponse, PegInOutResponse, PeginAddressResponse, PendingResponse,
     ReissueResponse, RpcResult, SpendResponse,
 };
-use clientd::{Event, EventLog, JsonDecodeTransaction};
+use clientd::{Event, EventLog};
 use minimint_api::Amount;
 use minimint_core::config::load_from_file;
 use minimint_core::modules::mint::tiered::coins::Coins;
@@ -147,7 +147,7 @@ async fn events(Extension(state): Extension<Arc<State>>, payload: Json<u64>) -> 
 
 async fn pegin(
     Extension(state): Extension<Arc<State>>,
-    payload: JsonDecodeTransaction,
+    payload: Json<PeginPayload>,
 ) -> impl IntoResponse {
     let client = &state.client;
     let event_log = &state.event_log;

--- a/client/clientd/src/main.rs
+++ b/client/clientd/src/main.rs
@@ -1,0 +1,62 @@
+mod utils;
+
+use crate::utils::responses::InfoResponse;
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::{Extension, Json, Router, Server};
+use clap::Parser;
+use minimint_core::config::load_from_file;
+use mint_client::{ClientAndGatewayConfig, UserClient};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tower::ServiceBuilder;
+use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer};
+use tracing::Level;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser)]
+struct Config {
+    workdir: PathBuf,
+}
+struct State {
+    client: UserClient,
+}
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+    let opts: Config = Config::parse();
+    let cfg_path = opts.workdir.join("client.json");
+    let db_path = opts.workdir.join("client.db");
+    let cfg: ClientAndGatewayConfig = load_from_file(&cfg_path);
+    let db = sled::open(&db_path)
+        .unwrap()
+        .open_tree("mint-client")
+        .unwrap();
+    let client = UserClient::new(cfg.client, Box::new(db), Default::default());
+
+    let shared_state = Arc::new(State { client });
+    let app = Router::new().route("/getInfo", post(info)).layer(
+        ServiceBuilder::new()
+            .layer(
+                TraceLayer::new_for_http()
+                    .make_span_with(DefaultMakeSpan::new().include_headers(true))
+                    .on_request(DefaultOnRequest::new().level(Level::INFO))
+                    .on_response(DefaultOnResponse::new().level(Level::INFO)),
+            )
+            .layer(Extension(shared_state)),
+    );
+
+    Server::bind(&"127.0.0.1:8081".parse().unwrap())
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}
+
+async fn info(Extension(state): Extension<Arc<State>>) -> impl IntoResponse {
+    Json(InfoResponse::build(state.client.coins()))
+}

--- a/client/clientd/src/utils.rs
+++ b/client/clientd/src/utils.rs
@@ -45,6 +45,11 @@ pub mod responses {
     use crate::utils::CoinsByTier;
 
     #[derive(Serialize)]
+    pub enum RpcResult {
+        Success(serde_json::Value),
+        Failure(serde_json::Value),
+    }
+    #[derive(Serialize)]
     pub struct InfoResponse {
         coins: Vec<CoinsByTier>,
         pending: PendingResponse,

--- a/client/clientd/src/utils.rs
+++ b/client/clientd/src/utils.rs
@@ -62,7 +62,7 @@ pub mod responses {
     }
 
     impl InfoResponse {
-        pub fn build(coins: Coins<SpendableCoin>, cfd: Vec<CoinFinalizationData>) -> Self {
+        pub fn new(coins: Coins<SpendableCoin>, cfd: Vec<CoinFinalizationData>) -> Self {
             let info_coins: Vec<CoinsByTier> = coins
                 .coins
                 .iter()

--- a/client/clientd/src/utils.rs
+++ b/client/clientd/src/utils.rs
@@ -24,6 +24,11 @@ pub mod responses {
         acc_val_amount: Amount,
     }
 
+    #[derive(Serialize)]
+    pub struct PeginAddressResponse {
+        pegin_address: bitcoin::Address,
+    }
+
     impl InfoResponse {
         pub fn build(coins: Coins<SpendableCoin>, cfd: Vec<CoinFinalizationData>) -> Self {
             let info_coins: Vec<CoinsByTier> = coins
@@ -50,6 +55,12 @@ pub mod responses {
                 acc_qty_coins,
                 acc_val_amount,
             }
+        }
+    }
+
+    impl PeginAddressResponse {
+        pub fn new(pegin_address: bitcoin::Address) -> Self {
+            Self { pegin_address }
         }
     }
 }

--- a/client/clientd/src/utils.rs
+++ b/client/clientd/src/utils.rs
@@ -25,6 +25,14 @@ pub mod payload {
         pub txout_proof: TxOutProof,
         pub transaction: Transaction,
     }
+
+    //TODO: remove this and also super::serde_invoice, when lightning_invoice "serde" feature becomes available
+    #[derive(Deserialize)]
+    #[serde(transparent)]
+    pub struct LnPayPayload {
+        #[serde(with = "super::serde_invoice")]
+        pub bolt11: lightning_invoice::Invoice,
+    }
 }
 
 pub mod responses {
@@ -122,6 +130,7 @@ pub mod responses {
         }
     }
 }
+
 // Holds quantity of coins per tier
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CoinsByTier {
@@ -189,6 +198,7 @@ impl EventLog {
 
 pub struct JsonDecodeTransaction(pub PeginPayload);
 //Alternative for this would be serde_from and impl from raw -> decoded
+//or TODO: rust-bitcoin transaction PR to not derive Deserialize but to impl it by hand, deciding dynamically weather it needs to be decoded first
 #[async_trait]
 impl<B> FromRequest<B> for JsonDecodeTransaction
 where

--- a/client/clientd/src/utils.rs
+++ b/client/clientd/src/utils.rs
@@ -56,6 +56,11 @@ pub mod responses {
         txid: TransactionId,
     }
 
+    #[derive(Serialize)]
+    pub struct SpendResponse {
+        pub coins: Coins<SpendableCoin>,
+    }
+
     impl InfoResponse {
         pub fn build(coins: Coins<SpendableCoin>, cfd: Vec<CoinFinalizationData>) -> Self {
             let info_coins: Vec<CoinsByTier> = coins
@@ -94,6 +99,12 @@ pub mod responses {
     impl PegInOutResponse {
         pub fn new(txid: TransactionId) -> Self {
             Self { txid }
+        }
+    }
+
+    impl SpendResponse {
+        pub fn new(coins: Coins<SpendableCoin>) -> Self {
+            Self { coins }
         }
     }
 }

--- a/client/clientd/src/utils.rs
+++ b/client/clientd/src/utils.rs
@@ -213,3 +213,31 @@ where
         Ok(Self(decoded))
     }
 }
+
+mod serde_invoice {
+    use serde::de::Error;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    #[allow(missing_docs)]
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<lightning_invoice::Invoice, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bolt11 = String::deserialize(deserializer)?
+            .parse::<lightning_invoice::Invoice>()
+            .map_err(|e| D::Error::custom(format!("{:?}", e)))?;
+
+        Ok(bolt11)
+    }
+    #[allow(missing_docs)]
+    #[allow(dead_code)]
+    pub fn serialize<S>(
+        invoice: &lightning_invoice::Invoice,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(invoice.to_string().as_str())
+    }
+}

--- a/client/clientd/src/utils.rs
+++ b/client/clientd/src/utils.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+
+pub mod payload {
+    //TODO
+}
+
+pub mod responses {
+    use crate::utils::CoinsByTier;
+    use minimint_core::modules::mint::tiered::coins::Coins;
+    use mint_client::mint::SpendableCoin;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    pub struct InfoResponse {
+        coins: Vec<CoinsByTier>,
+    }
+
+    impl InfoResponse {
+        pub fn build(coins: Coins<SpendableCoin>) -> Self {
+            let info_coins: Vec<CoinsByTier> = coins
+                .coins
+                .iter()
+                .map(|(tier, c)| super::CoinsByTier {
+                    quantity: c.len(),
+                    tier: tier.milli_sat,
+                })
+                .collect();
+            Self { coins: info_coins }
+        }
+    }
+}
+
+// Holds quantity of coins per tier
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CoinsByTier {
+    tier: u64,
+    quantity: usize,
+}

--- a/client/clientd/src/utils.rs
+++ b/client/clientd/src/utils.rs
@@ -38,8 +38,9 @@ pub mod payload {
 pub mod responses {
     use serde::Serialize;
 
-    use minimint_api::{Amount, TransactionId};
+    use minimint_api::{Amount, OutPoint, TransactionId};
     use minimint_core::modules::mint::tiered::coins::Coins;
+    use minimint_core::outcome::TransactionStatus;
     use mint_client::mint::{CoinFinalizationData, SpendableCoin};
 
     use crate::utils::CoinsByTier;
@@ -80,6 +81,12 @@ pub mod responses {
     #[derive(Serialize)]
     pub struct EventsResponse {
         events: Vec<super::Event>,
+    }
+
+    #[derive(Serialize)]
+    pub struct ReissueResponse {
+        out_point: OutPoint,
+        status: TransactionStatus,
     }
 
     impl InfoResponse {
@@ -132,6 +139,12 @@ pub mod responses {
     impl EventsResponse {
         pub fn new(events: Vec<super::Event>) -> Self {
             Self { events }
+        }
+    }
+
+    impl ReissueResponse {
+        pub fn new(out_point: OutPoint, status: TransactionStatus) -> Self {
+            Self { out_point, status }
         }
     }
 }

--- a/client/clientd/src/utils.rs
+++ b/client/clientd/src/utils.rs
@@ -6,26 +6,50 @@ pub mod payload {
 
 pub mod responses {
     use crate::utils::CoinsByTier;
+    use minimint_api::Amount;
     use minimint_core::modules::mint::tiered::coins::Coins;
-    use mint_client::mint::SpendableCoin;
+    use mint_client::mint::{CoinFinalizationData, SpendableCoin};
     use serde::Serialize;
 
     #[derive(Serialize)]
     pub struct InfoResponse {
         coins: Vec<CoinsByTier>,
+        pending: PendingResponse,
+    }
+
+    #[derive(Serialize)]
+    pub struct PendingResponse {
+        transactions: usize,
+        acc_qty_coins: usize,
+        acc_val_amount: Amount,
     }
 
     impl InfoResponse {
-        pub fn build(coins: Coins<SpendableCoin>) -> Self {
+        pub fn build(coins: Coins<SpendableCoin>, cfd: Vec<CoinFinalizationData>) -> Self {
             let info_coins: Vec<CoinsByTier> = coins
                 .coins
                 .iter()
-                .map(|(tier, c)| super::CoinsByTier {
+                .map(|(tier, c)| CoinsByTier {
                     quantity: c.len(),
                     tier: tier.milli_sat,
                 })
                 .collect();
-            Self { coins: info_coins }
+            Self {
+                coins: info_coins,
+                pending: PendingResponse::new(cfd),
+            }
+        }
+    }
+
+    impl PendingResponse {
+        pub fn new(all_pending: Vec<CoinFinalizationData>) -> Self {
+            let acc_qty_coins = all_pending.iter().map(|cfd| cfd.coin_count()).sum();
+            let acc_val_amount = all_pending.iter().map(|cfd| cfd.coin_amount()).sum();
+            Self {
+                transactions: all_pending.len(),
+                acc_qty_coins,
+                acc_val_amount,
+            }
         }
     }
 }

--- a/client/rest-client-cli/Cargo.toml
+++ b/client/rest-client-cli/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rest-client-cli"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clientd = { path = "../clientd" }
+mint-client = { path = "../client-lib" }
+minimint-api = { path = "../../minimint-api" }
+minimint-core = { path = "../../minimint-core" }
+anyhow = "1.0.58"
+base64 = "0.13.0"
+bitcoin = "0.27.0"
+clap = { version = "3.1.18", features = ["derive"] }
+reqwest = { version = "0.11.0", features = [ "json" ] }
+tokio = { version = "1.0.1", features = ["full"] }
+lightning-invoice = "0.14.0"
+serde = { version = "1.0.118", features = [ "derive" ] }
+serde_json = { version = "1"}

--- a/client/rest-client-cli/src/main.rs
+++ b/client/rest-client-cli/src/main.rs
@@ -1,0 +1,154 @@
+use anyhow::Result;
+use bitcoin::Transaction;
+use clap::{Parser, Subcommand};
+use clientd::call;
+use clientd::payload::{LnPayPayload, PeginPayload, PegoutPayload};
+use clientd::responses::{RpcResult, SpendResponse};
+use minimint_api::Amount;
+use minimint_core::modules::mint::tiered::coins::Coins;
+use minimint_core::modules::wallet::txoproof::TxOutProof;
+use mint_client::mint::SpendableCoin;
+use mint_client::utils::{from_hex, parse_bitcoin_amount, parse_coins};
+use serde::Serialize;
+use serde_json::json;
+
+#[derive(Parser)]
+#[clap(author, version, about = "a json-rpc cli application")]
+struct Cli {
+    /// print unformatted json
+    #[clap(takes_value = false, long = "raw", short = 'r')]
+    raw_json: bool,
+    /// call JSON-2.0 RPC method
+    #[clap(subcommand)]
+    command: Commands,
+}
+#[derive(Subcommand)]
+enum Commands {
+    /// rpc-method: info()
+    Info,
+    /// rpc-method: pending()
+    Pending,
+    /// rpc-method: events(timestamp: u64)
+    #[clap(arg_required_else_help = true)]
+    Events {
+        /// Unix timestamp
+        timestamp: u64,
+    },
+    /// rpc-method: pegin_address()
+    NewPeginAddress,
+    /// rpc-method: pegin(pegin: {tx_out_proof, transaction})
+    #[clap(arg_required_else_help = true)]
+    PegIn {
+        /// The TxOutProof which was created from sending BTC to the pegin-address
+        #[clap(parse(try_from_str = from_hex))]
+        txout_proof: TxOutProof,
+        /// The Bitcoin Transaction
+        #[clap(parse(try_from_str = from_hex))]
+        transaction: Transaction,
+    },
+    /// rpc-method: peg_out(pegout_req: {address, amount})
+    #[clap(arg_required_else_help = true)]
+    PegOut {
+        /// A bitcoin address
+        address: bitcoin::Address,
+        /// The bitcoin amount in satoshis (not msat!)
+        #[clap(parse(try_from_str = parse_bitcoin_amount))]
+        amount: bitcoin::Amount,
+    },
+    /// rpc-method: spend(amount: Amount)
+    #[clap(arg_required_else_help = true)]
+    Spend {
+        /// A minimint (ecash) amount
+        amount: Amount,
+        /// don't encode coins
+        #[clap(takes_value = false, long = "raw", short = 'r')]
+        raw_coins: bool,
+    },
+    /// rpc-method: lnpay(invoice_req: {bolt11: Invoice})
+    LnPay {
+        /// The amount of coins to be spend in msat if not set to sat
+        #[clap(parse(try_from_str = str::parse::<lightning_invoice::Invoice>))]
+        bolt11: lightning_invoice::Invoice,
+    },
+    /// rpc-method: reissue_validate(coins: Coins<SpendableCoin>)
+    #[clap(arg_required_else_help = true)]
+    Reissue {
+        /// The base64 encoded coins
+        #[clap(parse(from_str = parse_coins))]
+        coins: Coins<SpendableCoin>,
+        #[clap(takes_value = false, long = "quiet", short = 'q')]
+        /// call reissue without validation
+        quiet: bool,
+    },
+}
+#[tokio::main]
+async fn main() {
+    let args = Cli::parse();
+
+    match args.command {
+        Commands::Info => {
+            print_json(call("", "/getInfo").await, args.raw_json);
+        }
+        Commands::Pending => {
+            print_json(call("", "/getPending").await, args.raw_json);
+        }
+        Commands::Events { timestamp } => {
+            print_json(call(&timestamp, "/getEvents").await, args.raw_json);
+        }
+        Commands::NewPeginAddress => {
+            print_json(call("", "/getPeginAdress").await, args.raw_json);
+        }
+        Commands::PegIn {
+            txout_proof,
+            transaction,
+        } => {
+            let params = PeginPayload {
+                txout_proof,
+                transaction,
+            };
+            print_json(call(&params, "/pegin").await, args.raw_json);
+        }
+        Commands::PegOut { address, amount } => {
+            let params = PegoutPayload { address, amount };
+            print_json(call(&params, "/pegout").await, args.raw_json);
+        }
+        Commands::Spend { amount, raw_coins } => {
+            let res = call(&amount, "/spend").await.map(|r| {
+                if raw_coins {
+                    r
+                } else if let RpcResult::Success(v) = r {
+                    let coins: SpendResponse = serde_json::from_value(v).unwrap();
+                    let coins = coins.serialized();
+                    RpcResult::Success(json!(coins))
+                } else {
+                    r
+                }
+            });
+            print_json(res, args.raw_json);
+        }
+        Commands::LnPay { bolt11 } => {
+            let params = LnPayPayload { bolt11 };
+            print_json(call(&params, "/lnpay").await, args.raw_json);
+        }
+        Commands::Reissue { coins, quiet } => {
+            if quiet {
+                print_json(call(&coins, "/reissue").await, args.raw_json);
+            } else {
+                print_json(call(&coins, "/reissueValidate").await, args.raw_json);
+            }
+        }
+    }
+}
+
+fn print_json<T: Serialize>(result: Result<T>, raw: bool) {
+    match result {
+        Ok(p) => {
+            if raw {
+                println!("{}", serde_json::to_string(&p).unwrap());
+            } else {
+                println!("{}", serde_json::to_string_pretty(&p).unwrap());
+            }
+        }
+        Err(e) => eprintln!("{}", e),
+    }
+}


### PR DESCRIPTION
Because of #155 I decided to switch back (from json 2.0 rpc) to REST approach I think this is also easier to review. 
(since I already worked on json 2.0 now I think if it is wanted we can add it or switch the rest api for it quickly)
TODOs: 
- integration tests (rust/shell)
- documentation

HELP:
Because I'm not following json 2.0 standard anymore I noticed my expected request payload and my response objects lack consistency but I don't really know how to introduce some kind of standard.

NOTICE:
- The serde module can be removed when the serde feature of[ lightning-invoice](https://github.com/lightningdevkit/rust-lightning.git) is available and #176 is merged (or partly merged)
- The lnpay/spend concurrency problem is not solved I wanted to wait for #80 to be solved and then just add it in /spend /lnpay with an interactive rebase