### PR TITLE
Drop non-contributing peers in LN module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,6 +1924,7 @@ dependencies = [
  "mint-client",
  "rand 0.6.5",
  "serde",
+ "threshold_crypto 0.4.0",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/client/client-lib/src/clients/user.rs
+++ b/client/client-lib/src/clients/user.rs
@@ -47,9 +47,9 @@ pub struct UserClient {
 /// Invoice whose "offer" hasn't yet been accepted by federation
 pub struct UnconfirmedInvoice {
     /// The invoice itself
-    invoice: Invoice,
+    pub invoice: Invoice,
     /// The outpoint which creates the "offer" this invoice depends on
-    outpoint: OutPoint,
+    pub outpoint: OutPoint,
 }
 
 impl UserClient {

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -27,3 +27,4 @@ tokio = { version = "1.0.1", features = ["full"] }
 tracing ="0.1.22"
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }
 hbbft = { git = "https://github.com/fedimint/hbbft", branch = "minimint" }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }


### PR DESCRIPTION
Drops peers who don't contribute valid decryption shares.

Allows us to finally close #72 now that all modules are dropping non-contributing peers.