### PR TITLE
fix client not sending requests to enough peers

### DIFF
--- a/client/client-lib/src/clients/gateway.rs
+++ b/client/client-lib/src/clients/gateway.rs
@@ -46,6 +46,7 @@ pub struct PaymentParameters {
 impl GatewayClient {
     pub fn new(cfg: GatewayClientConfig, db: Box<dyn Database>) -> Self {
         let api = api::HttpFederationApi::new(
+            cfg.common.max_evil,
             cfg.common
                 .api_endpoints
                 .iter()

--- a/client/client-lib/src/clients/user.rs
+++ b/client/client-lib/src/clients/user.rs
@@ -55,6 +55,7 @@ pub struct UnconfirmedInvoice {
 impl UserClient {
     pub fn new(cfg: ClientConfig, db: Box<dyn Database>, secp: Secp256k1<All>) -> Self {
         let api = api::HttpFederationApi::new(
+            cfg.max_evil,
             cfg.api_endpoints
                 .iter()
                 .enumerate()

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -281,6 +281,7 @@ impl UserTest {
 
     fn new(config: ClientConfig, peers: Vec<PeerId>) -> Self {
         let api = Box::new(HttpFederationApi::new(
+            config.max_evil,
             config
                 .api_endpoints
                 .iter()

--- a/minimint-core/src/config.rs
+++ b/minimint-core/src/config.rs
@@ -12,6 +12,7 @@ pub struct ClientConfig {
     pub wallet: WalletClientConfig,
     pub ln: LightningModuleClientConfig,
     pub fee_consensus: FeeConsensus,
+    pub max_evil: usize,
 }
 
 // TODO: get rid of it here, modules should govern their oen fees

--- a/minimint/src/config.rs
+++ b/minimint/src/config.rs
@@ -119,6 +119,7 @@ impl GenerateConfig for ServerConfig {
             .collect();
 
         let client_config = ClientConfig {
+            max_evil,
             api_endpoints: peers
                 .iter()
                 .map(|&peer| {


### PR DESCRIPTION
This fixes the CI tests getting stalled due to the user sending a tx to only 1 slow peer that might not be able to contribute that tx to consensus.  The solution is the client needs to be changed to send txs to at least max_evil + 1 peers.

I was able to reproduce the issue by `thread::sleeping` in the HBBFT send message loop.  Interestingly the peer that starts a HBBFT proposal will not necessarily be the peer included in the final proposal.

Long-term we should improve the client code to send to all peers concurrently so if one of the peers is unreachable we don't block forever.  Additionally we should version our APIs with the epoch # so we can verify peers are returning the same results if on the same epoch.