### PR TITLE
build audits into modules

### DIFF
--- a/minimint-api/src/module/audit.rs
+++ b/minimint-api/src/module/audit.rs
@@ -1,0 +1,62 @@
+use crate::db::{Database, DatabaseKeyPrefix, DatabaseKeyPrefixConst};
+
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+
+#[derive(Default)]
+pub struct Audit {
+    items: Vec<AuditItem>,
+}
+
+impl Audit {
+    pub fn sum(&self) -> AuditItem {
+        let mut sum = 0;
+
+        for item in &self.items {
+            sum += item.milli_sat;
+        }
+        AuditItem {
+            name: "Total sats".to_string(),
+            milli_sat: sum,
+        }
+    }
+
+    pub fn add_items<KP, F>(&mut self, db: &Arc<dyn Database>, key_prefix: &KP, to_milli_sat: F)
+    where
+        KP: DatabaseKeyPrefix + DatabaseKeyPrefixConst + 'static,
+        F: Fn(KP::Key, KP::Value) -> i64,
+    {
+        let mut new_items = db
+            .find_by_prefix(key_prefix)
+            .map(|res| {
+                let (key, value) = res.expect("DB error");
+                let name = format!("{:?}", key);
+                let milli_sat = to_milli_sat(key, value);
+                AuditItem { name, milli_sat }
+            })
+            .collect();
+        self.items.append(&mut new_items);
+    }
+}
+
+impl Display for Audit {
+    fn fmt(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str("- Balance Sheet -")?;
+        for item in &self.items {
+            formatter.write_fmt(format_args!("\n{}", item))?;
+        }
+        formatter.write_fmt(format_args!("\n{}", self.sum()))
+    }
+}
+
+pub struct AuditItem {
+    pub name: String,
+    pub milli_sat: i64,
+}
+
+impl Display for AuditItem {
+    fn fmt(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        let sats = (self.milli_sat as f64) / 1000.0;
+        formatter.write_fmt(format_args!("{:>+15.3}|{}", sats, self.name))
+    }
+}

--- a/minimint-api/src/module/mod.rs
+++ b/minimint-api/src/module/mod.rs
@@ -1,3 +1,4 @@
+pub mod audit;
 pub mod interconnect;
 pub mod testing;
 
@@ -9,6 +10,7 @@ use secp256k1_zkp::rand::RngCore;
 use secp256k1_zkp::XOnlyPublicKey;
 use std::collections::{HashMap, HashSet};
 
+use crate::module::audit::Audit;
 use crate::module::interconnect::ModuleInterconect;
 pub use http_types as http;
 
@@ -141,6 +143,12 @@ pub trait FederationModule: Sized {
     /// needed by the client to access funds or give an estimate of when funds will be available.
     /// Returns `None` if the output is unknown, **NOT** if it is just not ready yet.
     fn output_status(&self, out_point: crate::OutPoint) -> Option<Self::TxOutputOutcome>;
+
+    /// Queries the database and returns all assets and liabilities of the module.
+    ///
+    /// Summing over all modules, if liabilities > assets then an error has occurred in the database
+    /// and consensus should halt.
+    fn audit(&self, audit: &mut Audit);
 
     /// Defines the prefix for API endpoints defined by the module.
     ///

--- a/minimint/src/config.rs
+++ b/minimint/src/config.rs
@@ -89,9 +89,9 @@ impl GenerateConfig for ServerConfig {
 
         let fee_consensus = FeeConsensus {
             fee_coin_spend_abs: minimint_api::Amount::ZERO,
-            fee_peg_in_abs: minimint_api::Amount::from_sat(500),
+            fee_peg_in_abs: minimint_api::Amount::from_sat(1000),
             fee_coin_issuance_abs: minimint_api::Amount::ZERO,
-            fee_peg_out_abs: minimint_api::Amount::from_sat(500),
+            fee_peg_out_abs: minimint_api::Amount::from_sat(1000),
             fee_contract_input: minimint_api::Amount::ZERO,
             fee_contract_output: minimint_api::Amount::ZERO,
         };

--- a/minimint/src/consensus/debug.rs
+++ b/minimint/src/consensus/debug.rs
@@ -29,19 +29,19 @@ fn item_message(item: &ConsensusItem) -> String {
         ConsensusItem::Wallet(WalletConsensusItem::PegOutSignature(PegOutSignatureItem {
             txid,
             ..
-        })) => format!("Wallet Peg Out PSBT {:.8}", txid),
+        })) => format!("Wallet Peg Out PSBT {}", txid),
         ConsensusItem::Mint(PartiallySignedRequest {
             out_point,
             partial_signature,
         }) => {
             format!(
-                "Mint Signed Coins {} with TxId {:.8}",
+                "Mint Signed Coins {} with TxId {}",
                 partial_signature.0.amount(),
                 out_point.txid
             )
         }
         ConsensusItem::LN(DecryptionShareCI { contract_id, .. }) => {
-            format!("LN Decrytion Share for contract {:.8}", contract_id)
+            format!("LN Decrytion Share for contract {}", contract_id)
         }
         ConsensusItem::Transaction(Transaction {
             inputs, outputs, ..
@@ -51,10 +51,10 @@ fn item_message(item: &ConsensusItem) -> String {
                 let input_debug = match input {
                     Input::Mint(t) => format!("Mint Coins {}", t.amount()),
                     Input::Wallet(t) => {
-                        format!("Wallet PegIn with TxId {:.8}", t.outpoint().txid)
+                        format!("Wallet PegIn with TxId {}", t.outpoint().txid)
                     }
                     Input::LN(t) => {
-                        format!("LN Contract {} with id {:.8}", t.amount, t.contract_id)
+                        format!("LN Contract {} with id {}", t.amount, t.contract_id)
                     }
                 };
                 write!(tx_debug, "\n    Input: {}", input_debug).unwrap();
@@ -63,23 +63,23 @@ fn item_message(item: &ConsensusItem) -> String {
                 let output_debug = match output {
                     Output::Mint(t) => format!("Mint Coins {}", t.amount()),
                     Output::Wallet(t) => {
-                        format!("Wallet PegOut {} to address {:.8}", t.amount, t.recipient)
+                        format!("Wallet PegOut {} to address {}", t.amount, t.recipient)
                     }
                     Output::LN(ContractOrOfferOutput::Offer(o)) => {
-                        format!("LN Offer for {} with hash {:.8}", o.amount, o.hash)
+                        format!("LN Offer for {} with hash {}", o.amount, o.hash)
                     }
                     Output::LN(ContractOrOfferOutput::Contract(ContractOutput {
                         amount,
                         contract,
                     })) => match contract {
                         Contract::Account(a) => {
-                            format!("LN Account Contract for {} key {:.8}", amount, a.key)
+                            format!("LN Account Contract for {} key {}", amount, a.key)
                         }
                         Contract::Incoming(a) => {
-                            format!("LN Incoming Contract for {} hash {:.8}", amount, a.hash)
+                            format!("LN Incoming Contract for {} hash {}", amount, a.hash)
                         }
                         Contract::Outgoing(a) => {
-                            format!("LN Outgoing Contract for {} hash {:.8}", amount, a.hash)
+                            format!("LN Outgoing Contract for {} hash {}", amount, a.hash)
                         }
                     },
                 };

--- a/modules/minimint-ln/src/db.rs
+++ b/modules/minimint-ln/src/db.rs
@@ -20,6 +20,15 @@ impl DatabaseKeyPrefixConst for ContractKey {
     type Value = ContractAccount;
 }
 
+#[derive(Debug, Clone, Copy, Encodable, Decodable)]
+pub struct ContractKeyPrefix;
+
+impl DatabaseKeyPrefixConst for ContractKeyPrefix {
+    const DB_PREFIX: u8 = DB_PREFIX_CONTRACT;
+    type Key = ContractKey;
+    type Value = ContractAccount;
+}
+
 #[derive(Debug, Encodable, Decodable)]
 pub struct ContractUpdateKey(pub OutPoint);
 

--- a/modules/minimint-ln/src/lib.rs
+++ b/modules/minimint-ln/src/lib.rs
@@ -20,8 +20,9 @@ use crate::contracts::{
     Contract, ContractId, ContractOutcome, FundedContract, IdentifyableContract,
 };
 use crate::db::{
-    AgreedDecryptionShareKey, AgreedDecryptionShareKeyPrefix, ContractKey, ContractUpdateKey,
-    OfferKey, OfferKeyPrefix, ProposeDecryptionShareKey, ProposeDecryptionShareKeyPrefix,
+    AgreedDecryptionShareKey, AgreedDecryptionShareKeyPrefix, ContractKey, ContractKeyPrefix,
+    ContractUpdateKey, OfferKey, OfferKeyPrefix, ProposeDecryptionShareKey,
+    ProposeDecryptionShareKeyPrefix,
 };
 use async_trait::async_trait;
 use bitcoin_hashes::Hash as BitcoinHash;
@@ -29,6 +30,7 @@ use itertools::Itertools;
 use minimint_api::db::batch::{BatchItem, BatchTx};
 use minimint_api::db::Database;
 use minimint_api::encoding::{Decodable, Encodable};
+use minimint_api::module::audit::Audit;
 use minimint_api::module::interconnect::ModuleInterconect;
 use minimint_api::module::{http, ApiEndpoint};
 use minimint_api::{Amount, FederationModule, PeerId};
@@ -515,6 +517,12 @@ impl FederationModule for LightningModule {
         self.db
             .get_value(&ContractUpdateKey(out_point))
             .expect("DB error")
+    }
+
+    fn audit(&self, audit: &mut Audit) {
+        audit.add_items(&self.db, &ContractKeyPrefix, |_, v| {
+            -(v.amount.milli_sat as i64)
+        });
     }
 
     fn api_base_name(&self) -> &'static str {

--- a/modules/minimint-mint/src/db.rs
+++ b/modules/minimint-mint/src/db.rs
@@ -1,12 +1,13 @@
 use crate::{CoinNonce, PartialSigResponse, SigResponse};
 use minimint_api::db::DatabaseKeyPrefixConst;
 use minimint_api::encoding::{Decodable, Encodable};
-use minimint_api::{OutPoint, PeerId};
+use minimint_api::{Amount, OutPoint, PeerId};
 
 const DB_PREFIX_COIN_NONCE: u8 = 0x10;
 const DB_PREFIX_PROPOSED_PARTIAL_SIG: u8 = 0x11;
 const DB_PREFIX_RECEIVED_PARTIAL_SIG: u8 = 0x12;
 const DB_PREFIX_OUTPUT_OUTCOME: u8 = 0x13;
+const DB_PREFIX_MINT_AUDIT_ITEM: u8 = 0x14;
 
 #[derive(Debug, Clone, Encodable, Decodable, Eq, PartialEq, Hash)]
 pub struct NonceKey(pub CoinNonce);
@@ -77,4 +78,28 @@ impl DatabaseKeyPrefixConst for OutputOutcomeKey {
     const DB_PREFIX: u8 = DB_PREFIX_OUTPUT_OUTCOME;
     type Key = Self;
     type Value = SigResponse;
+}
+
+/// Represents the amounts of issued (signed) and redeemed (verified) coins for auditing
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub enum MintAuditItemKey {
+    Issuance(OutPoint),
+    IssuanceTotal,
+    Redemption(NonceKey),
+    RedemptionTotal,
+}
+
+impl DatabaseKeyPrefixConst for MintAuditItemKey {
+    const DB_PREFIX: u8 = DB_PREFIX_MINT_AUDIT_ITEM;
+    type Key = Self;
+    type Value = Amount;
+}
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct MintAuditItemKeyPrefix;
+
+impl DatabaseKeyPrefixConst for MintAuditItemKeyPrefix {
+    const DB_PREFIX: u8 = DB_PREFIX_MINT_AUDIT_ITEM;
+    type Key = MintAuditItemKey;
+    type Value = Amount;
 }

--- a/modules/minimint-wallet/src/config.rs
+++ b/modules/minimint-wallet/src/config.rs
@@ -67,7 +67,7 @@ impl GenerateConfig for WalletConfig {
                         .collect(),
                     peg_in_key: *sk,
                     finalty_delay: 10,
-                    default_fee: Feerate { sats_per_kvb: 2000 },
+                    default_fee: Feerate { sats_per_kvb: 1000 },
                     btc_rpc_address: "127.0.0.1:18443".to_string(),
                     btc_rpc_user: "bitcoin".to_string(),
                     btc_rpc_pass: "bitcoin".to_string(),


### PR DESCRIPTION
Adds an audit of the balance sheet of the federation, closes #128.
- If the balance sheet is negative (more liabilities than assets) the federation will panic
- To ensure this never happens we need to address #196
- Eventually the audits will need to be aggregated or use a DB query as the number of minted coins grows
- Prints a very useful balance sheet message during testing (or when panic occurs):

```
- Balance Sheet -
      -3000.000|OutputOutcomeKey(OutPoint { txid: 0000000000000000000000000000000000000000000000000000000000000000, out_idx: 0 })
      -2000.000|OutputOutcomeKey(OutPoint { txid: 525e269e815c7167ff9d5b4b239da32a24d12a76eab517d72aa150f22c466a87, out_idx: 0 })
      +1000.000|NonceKey(CoinNonce(XOnlyPublicKey(4cc953dac7ea38ba126b2eaf75513540c2af2a79ace8bc91de7786a5b3aded497e1c72118036ff7ea80fdd11f9fc5ac95fba4a1d66940515dfffb9c511d27ad7)))
      +1000.000|NonceKey(CoinNonce(XOnlyPublicKey(f2e75f624b67befde2f3f321eec61d57a158e4cdf027a58ff3b0d229c9b04ee73425ac2f3798e2cb060303738740799814c952f3e86c38b26569e75b8b8063da)))
         +0.000|ContractKey(840e1d32b0fc98fa46e08c15cf6f29588269e545cea5d396b0eef56e677a18e7)
      +3000.000|UTXOKey(OutPoint { txid: ea8e4b8ceb26908c5c86db2453c86447169bda5856d6ed6f1c2c06386d05ba0c, vout: 0 })
         +0.000|Total sats
```