### PR TITLE
Default federation size of 4 for latencytest.sh

### DIFF
--- a/scripts/latencytest.sh
+++ b/scripts/latencytest.sh
@@ -2,7 +2,7 @@
 
 POLL_INTERVAL=1
 CONFIRMATION_TIME=10
-FED_SIZE=$1
+FED_SIZE=${1:-4}
 
 # Fail instantly if anything goes wrong and log executed commands
 set -e


### PR DESCRIPTION
Produces a confusing result currently https://discord.com/channels/990354215060795454/992503915578933268/992550624161964182

@jkitman is 4 a good number?