### PR TITLE
Add coin assertion helpers to UserTest

### DIFF
--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -308,6 +308,15 @@ impl UserTest {
             database,
         }
     }
+
+    pub async fn assert_total_coins(&self, amount: Amount) {
+        self.client.fetch_all_coins().await.unwrap();
+        assert_eq!(self.total_coins(), amount);
+    }
+    pub async fn assert_coin_amounts(&self, amounts: Vec<Amount>) {
+        self.client.fetch_all_coins().await.unwrap();
+        assert_eq!(self.coin_amounts(), amounts);
+    }
 }
 
 pub struct FederationTest {


### PR DESCRIPTION
I noticed that these two lines (1) fetch coins and (2) assertion about coins kept being repeated. 

I think these helpers improve the readability of our tests a little bit?