### PR TITLE
Use dev version of core-lightning for faster polling

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,6 +65,11 @@ jobs:
       - uses: cachix/install-nix-action@v15
         with:
           nix_path: nixpkgs=channel:nixos-22.05
+      - uses: cachix/cachix-action@v10
+        if: github.repository_owner == 'fedimint'
+        with:
+          name: fedimint
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - name: Integration Tests with nix-shell
         run: nix-shell --command ./scripts/integrationtest.sh
   nix-build_test:

--- a/scripts/integrationtest.sh
+++ b/scripts/integrationtest.sh
@@ -42,8 +42,8 @@ until [ "$($BTC_CLIENT getblockchaininfo | jq -r '.chain')" == "regtest" ]; do
 done
 
 # Start lightning nodes
-lightningd --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$LN1_DIR --addr=127.0.0.1:9000 &
-lightningd --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$LN2_DIR --addr=127.0.0.1:9001 &
+lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$LN1_DIR --addr=127.0.0.1:9000 &
+lightningd --dev-fast-gossip --dev-bitcoind-poll=1 --network regtest --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=bitcoin --lightning-dir=$LN2_DIR --addr=127.0.0.1:9001 &
 until [ -e $LN1_DIR/regtest/lightning-rpc ]; do
     sleep $POLL_INTERVAL
 done

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,9 @@ let
   } // pkgs.lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
     NIX_CFLAGS_COMPILE="-Wno-stringop-truncation";
   });
+  bitcoind-patch-darwin = pkgs.bitcoind.overrideAttrs (oldAttrs: {
+    doCheck = !(pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64);
+  });
 in
 pkgs.mkShell {
   packages = with pkgs; [
@@ -14,7 +17,7 @@ pkgs.mkShell {
     rustc
     cargo
     rust-analyzer
-    bitcoind
+    bitcoind-patch-darwin
     clightning-dev
     jq
     procps

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,11 @@
 { pkgs ? import <nixpkgs> {}}:
-
+let
+  clightning-dev = pkgs.clightning.overrideAttrs (oldAttrs: {
+    configureFlags = [ "--enable-developer" "--disable-valgrind" ];
+  } // pkgs.lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
+    NIX_CFLAGS_COMPILE="-Wno-stringop-truncation";
+  });
+in
 pkgs.mkShell {
   packages = with pkgs; [
     openssl
@@ -9,7 +15,7 @@ pkgs.mkShell {
     cargo
     rust-analyzer
     bitcoind
-    clightning
+    clightning-dev
     jq
     procps
   ] ++ lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
Core-lightning is doing some slow polling in production builds (e.g. channel openings, chain tip, …). Dev builds are said to speed things up or at least allow us to set `--dev-*` options to reduce polling latency. This should speed up integration tests.