### PR TITLE
Pin nixpkgs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,11 @@
-{ pkgs ? import <nixpkgs> {}}:
+let
+  nix-pinned = builtins.fetchTarball {
+    name = "nixos-22.05";
+    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/22.05.tar.gz";
+    sha256 = "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik";
+  };
+in
+{ pkgs ? import (nix-pinned) {}}:
 let
   clightning-dev = pkgs.clightning.overrideAttrs (oldAttrs: {
     configureFlags = [ "--enable-developer" "--disable-valgrind" ];


### PR DESCRIPTION
When debugging a problem in #210 with @justinmoon we noticed we were using different versions of nixpkgs. Even though it turned out not to be the cause of the problem we might want to make sure that everyone is using the same environment.

Depends on #210, do not merge before.