### PR TITLE
integrationtest.sh waits for operational lightning channel

### DIFF
--- a/scripts/integrationtest.sh
+++ b/scripts/integrationtest.sh
@@ -78,6 +78,7 @@ LN2_PUB_KEY="$($LN2 getinfo | jq -r '.id')"
 $LN1 connect $LN2_PUB_KEY@127.0.0.1:9001
 until $LN1 fundchannel $LN2_PUB_KEY 0.1btc; do sleep $POLL_INTERVAL; done
 mine_blocks 10
+until [[ $($LN1 listpeers | jq -r ".peers[] | select(.id == \"$LN2_PUB_KEY\") | .channels[0].state") = "CHANNELD_NORMAL" ]]; do sleep $POLL_INTERVAL; done
 
 # FIXME: make db path configurable to avoid cd-ing here
 # Start the federation members inside the temporary directory


### PR DESCRIPTION
Sometimes the integration tests would fail when trying to pay over lightning network because our our core-lightning channel was still in the `CHANNELD_AWAITING_LOCKIN` state and not in the `CHANNELD_NORMAL` state. Here we wait until `CHANNELD_NORMAL` has been observed before proceeding.