### PR TITLE
Use our own self-hosted GH actions runner

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   docs:
     name: Publish docs
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -4,7 +4,7 @@ name: Markdown Link Check
 
 jobs:
   markdown-link-check:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@master
       - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,7 @@ name: CI
 jobs:
   build_and_unit_test:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -40,7 +40,7 @@ jobs:
           args: --all -- --check
   build_wasm:
     name: Build (wasm32)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -58,7 +58,7 @@ jobs:
 
   build_and_integration_test:
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v1
@@ -74,7 +74,7 @@ jobs:
         run: nix-shell --command ./scripts/integrationtest.sh
   nix-build_test:
     name: Nix-Build Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2.4.0
       - uses: cachix/install-nix-action@v16
@@ -88,7 +88,7 @@ jobs:
       - run: nix-build
   nix-flake:
     name: Nix-flake Tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2.4.0
       - uses: cachix/install-nix-action@v16


### PR DESCRIPTION
* Fixes #217
* Reproducible: `sed -i "s/ubuntu-latest/self-hosted/g" .github/workflows/*`