### PR TITLE
Only build PR commits once

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 name: CI
 


### PR DESCRIPTION
I just noticed we are also building every PR commit twice. That's kinda silly and seems to block runners.