### PR TITLE
Lift dependencies up to top of file, remove redundant secp/zkp libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,7 @@ dependencies = [
  "opentelemetry-jaeger",
  "rand 0.6.5",
  "rayon",
- "secp256k1-zkp",
+ "secp256k1",
  "serde",
  "serde_json",
  "sha3",
@@ -1995,7 +1995,6 @@ dependencies = [
  "lightning-invoice",
  "minimint-derive",
  "rand 0.6.5",
- "secp256k1-zkp",
  "serde",
  "serde_json",
  "sled",
@@ -2110,6 +2109,7 @@ dependencies = [
  "minimint-ln",
  "minimint-mint",
  "minimint-wallet",
+ "miniscript",
  "mint-client",
  "rand 0.6.5",
  "serde",
@@ -2133,7 +2133,6 @@ dependencies = [
  "minimint-derive",
  "miniscript",
  "rand 0.6.5",
- "secp256k1",
  "serde",
  "test-log",
  "thiserror",
@@ -2184,7 +2183,6 @@ dependencies = [
  "minimint-core",
  "miniscript",
  "rand 0.6.5",
- "secp256k1-zkp",
  "serde",
  "serde_json",
  "tbs",
@@ -3155,7 +3153,6 @@ dependencies = [
  "rand 0.6.5",
  "secp256k1",
  "secp256k1-zkp-sys",
- "serde",
 ]
 
 [[package]]

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -8,6 +8,7 @@ use minimint_core::modules::wallet::txoproof::TxOutProof;
 use mint_client::mint::SpendableCoin;
 use mint_client::utils::{from_hex, parse_bitcoin_amount, parse_coins, serialize_coins};
 use mint_client::{ClientAndGatewayConfig, UserClient};
+use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::Duration;
@@ -84,7 +85,7 @@ async fn main() {
         .open_tree("mint-client")
         .unwrap();
 
-    let mut rng = rand::rngs::OsRng::new().unwrap();
+    let mut rng = OsRng::new().unwrap();
 
     let client = UserClient::new(cfg.client, Box::new(db), Default::default()).await;
 

--- a/client/client-lib/Cargo.toml
+++ b/client/client-lib/Cargo.toml
@@ -21,7 +21,6 @@ miniscript = "7.0.0"
 minimint-core = { path = "../../minimint-core" }
 minimint-api = { path = "../../minimint-api" }
 rand = "0.6.5"
-secp256k1-zkp = { version = "0.6.0", features = [ "serde", "bitcoin_hashes" ] }
 serde = "1.0.118"
 tbs = { path = "../../crypto/tbs" }
 thiserror = "1.0.23"

--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use bitcoin_hashes::sha256::Hash as Sha256Hash;
+use bitcoin_hashes::sha256;
 use futures::StreamExt;
 use jsonrpsee_core::client::ClientT;
 use jsonrpsee_core::Error as JsonRpcError;
@@ -29,7 +29,7 @@ pub trait FederationApi: Send + Sync {
     async fn fetch_contract(&self, contract: ContractId) -> Result<ContractAccount>;
 
     /// Fetch preimage offer for incoming lightning payments
-    async fn fetch_offer(&self, payment_hash: Sha256Hash) -> Result<IncomingContractOffer>;
+    async fn fetch_offer(&self, payment_hash: sha256::Hash) -> Result<IncomingContractOffer>;
 
     /// Fetch the current consensus block height (trailing actual block height)
     async fn fetch_consensus_block_height(&self) -> Result<u64>;
@@ -134,7 +134,7 @@ impl<C: ClientT + Send + Sync> FederationApi for WsFederationApi<C> {
         self.request("/wallet/block_height", ()).await
     }
 
-    async fn fetch_offer(&self, payment_hash: Sha256Hash) -> Result<IncomingContractOffer> {
+    async fn fetch_offer(&self, payment_hash: sha256::Hash) -> Result<IncomingContractOffer> {
         self.request("/ln/offer", payment_hash).await
     }
 }

--- a/client/client-lib/src/clients/transaction.rs
+++ b/client/client-lib/src/clients/transaction.rs
@@ -1,9 +1,9 @@
-use rand::{CryptoRng, RngCore};
-
 use bitcoin::KeyPair;
 use minimint_api::Amount;
 use minimint_core::config::FeeConsensus;
 use minimint_core::transaction::{Input, Output, Transaction};
+use rand::{CryptoRng, RngCore};
+use bitcoin::secp256k1::{All, Secp256k1};
 
 pub struct TransactionBuilder {
     keys: Vec<KeyPair>,
@@ -39,7 +39,7 @@ impl TransactionBuilder {
 
     pub fn build<R: RngCore + CryptoRng>(
         mut self,
-        secp: &secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
+        secp: &Secp256k1<All>,
         mut rng: R,
     ) -> Transaction {
         if !self.keys.is_empty() {

--- a/client/client-lib/src/clients/user.rs
+++ b/client/client-lib/src/clients/user.rs
@@ -5,9 +5,10 @@ use crate::ln::{LnClient, LnClientError};
 use crate::mint::{MintClient, MintClientError, SpendableCoin};
 use crate::wallet::{WalletClient, WalletClientError};
 use crate::{api, OwnedClientContext};
+use bitcoin::secp256k1::{All, Secp256k1};
 use bitcoin::util::key::KeyPair;
 use bitcoin::{Address, Network, Transaction as BitcoinTransaction};
-use bitcoin_hashes::Hash;
+use bitcoin_hashes::{sha256, Hash};
 use lightning::ln::PaymentSecret;
 use lightning_invoice::{CreationError, Currency, Invoice, InvoiceBuilder};
 use minimint_api::db::batch::{Accumulator, BatchItem, DbBatch};
@@ -25,7 +26,6 @@ use minimint_core::modules::mint::BlindToken;
 use minimint_core::modules::wallet::txoproof::TxOutProof;
 use minimint_core::transaction::{Input, Output, TransactionItem};
 use rand::{CryptoRng, RngCore};
-use secp256k1_zkp::{All, Secp256k1};
 use std::time::Duration;
 use thiserror::Error;
 
@@ -338,7 +338,7 @@ impl UserClient {
     ) -> Result<(KeyPair, UnconfirmedInvoice), ClientError> {
         let payment_keypair = KeyPair::new(&self.context.secp, &mut rng);
         let raw_payment_secret = payment_keypair.public_key().serialize();
-        let payment_hash = bitcoin::secp256k1::hashes::sha256::Hash::hash(&raw_payment_secret);
+        let payment_hash = sha256::Hash::hash(&raw_payment_secret);
         let payment_secret = PaymentSecret(raw_payment_secret);
 
         // Temporary lightning node pubkey

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -7,6 +7,7 @@ pub mod wallet;
 
 use crate::api::FederationApi;
 use crate::ln::gateway::LightningGateway;
+use bitcoin::secp256k1::{All, Secp256k1};
 pub use clients::user::UserClient;
 use minimint_api::db::Database;
 use minimint_core::config::ClientConfig;
@@ -16,14 +17,14 @@ pub struct BorrowedClientContext<'a, C> {
     config: &'a C,
     db: &'a dyn Database,
     api: &'a dyn FederationApi,
-    secp: &'a secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
+    secp: &'a Secp256k1<All>,
 }
 
 struct OwnedClientContext<C> {
     config: C,
     db: Box<dyn Database>,
     api: Box<dyn FederationApi>,
-    secp: secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
+    secp: Secp256k1<All>,
 }
 
 impl<CO> OwnedClientContext<CO> {

--- a/client/client-lib/src/ln/gateway.rs
+++ b/client/client-lib/src/ln/gateway.rs
@@ -1,9 +1,9 @@
-use bitcoin::secp256k1;
+use bitcoin::secp256k1::{PublicKey, XOnlyPublicKey};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LightningGateway {
-    pub mint_pub_key: secp256k1::XOnlyPublicKey,
-    pub node_pub_key: secp256k1::PublicKey,
+    pub mint_pub_key: XOnlyPublicKey,
+    pub node_pub_key: PublicKey,
     pub api: String,
 }

--- a/client/client-lib/src/utils.rs
+++ b/client/client-lib/src/utils.rs
@@ -1,4 +1,5 @@
 use crate::mint::SpendableCoin;
+use bitcoin::Denomination::Satoshi;
 use minimint_api::encoding::Decodable;
 use minimint_core::modules::mint::tiered::coins::Coins;
 
@@ -20,5 +21,5 @@ pub fn from_hex<D: Decodable>(s: &str) -> Result<D, anyhow::Error> {
 pub fn parse_bitcoin_amount(
     s: &str,
 ) -> Result<bitcoin::Amount, bitcoin::util::amount::ParseAmountError> {
-    bitcoin::Amount::from_str_in(s, bitcoin::Denomination::Satoshi)
+    bitcoin::Amount::from_str_in(s, Satoshi)
 }

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -20,6 +20,7 @@ minimint-api = { path = "../minimint-api" }
 minimint-ln = { path = "../modules/minimint-ln" }
 minimint-mint = { path = "../modules/minimint-mint" }
 minimint-wallet = { path = "../modules/minimint-wallet" }
+miniscript = { version = "7.0.0", features = [ "compiler", "use-serde" ] }
 mint-client = { path = "../client/client-lib" }
 rand = "0.6.5"
 serde = { version = "1.0.118", features = [ "derive" ] }

--- a/integrationtests/tests/fixtures/fake.rs
+++ b/integrationtests/tests/fixtures/fake.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use bitcoin::hash_types::Txid;
 use bitcoin::hashes::{sha256, Hash};
-use bitcoin::secp256k1::{PublicKey, SecretKey};
+use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use bitcoin::util::merkleblock::PartialMerkleTree;
 use bitcoin::{
     secp256k1, Address, Block, BlockHash, BlockHeader, KeyPair, Network, Transaction, TxOut,
@@ -18,6 +18,7 @@ use minimint_api::Amount;
 use minimint_wallet::bitcoind::BitcoindRpc;
 use minimint_wallet::txoproof::TxOutProof;
 use minimint_wallet::Feerate;
+use miniscript::ToPublicKey;
 
 use crate::fixtures::{BitcoinTest, LightningTest};
 
@@ -172,10 +173,10 @@ impl BitcoinTest for FakeBitcoinTest {
     }
 
     fn get_new_address(&self) -> Address {
-        let ctx = bitcoin::secp256k1::Secp256k1::new();
+        let ctx = Secp256k1::new();
         let (_, public_key) = ctx.generate_keypair(&mut OsRng::new().unwrap());
-
-        Address::p2wpkh(&bitcoin::PublicKey::new(public_key), Network::Regtest).unwrap()
+        let public_key = public_key.to_public_key();
+        Address::p2wpkh(&public_key, Network::Regtest).unwrap()
     }
 
     fn mine_block_and_get_received(&self, address: &Address) -> Amount {

--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -11,6 +11,8 @@ use std::time::Duration;
 
 use bitcoin::hashes::{sha256, Hash};
 use bitcoin::KeyPair;
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::secp256k1::Secp256k1;
 use bitcoin::{secp256k1, Address, Transaction};
 use cln_rpc::ClnRpc;
 use futures::executor::block_on;
@@ -206,10 +208,10 @@ impl GatewayTest {
     async fn new(
         ln_client: Box<dyn LnRpc>,
         client_config: ClientConfig,
-        node_pub_key: secp256k1::PublicKey,
+        node_pub_key: PublicKey,
     ) -> Self {
         let mut rng = OsRng::new().unwrap();
-        let ctx = bitcoin::secp256k1::Secp256k1::new();
+        let ctx = Secp256k1::new();
         let kp = KeyPair::new(&ctx, &mut rng);
 
         let federation_client = GatewayClientConfig {

--- a/ln-gateway/src/bin/gw_configgen.rs
+++ b/ln-gateway/src/bin/gw_configgen.rs
@@ -5,7 +5,7 @@ use mint_client::clients::gateway::GatewayClientConfig;
 use mint_client::ln::gateway::LightningGateway;
 use mint_client::ClientAndGatewayConfig;
 use rand::thread_rng;
-use secp256k1::{KeyPair, PublicKey};
+use secp256k1::{KeyPair, PublicKey, Secp256k1};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -22,7 +22,7 @@ fn main() {
         load_from_file(&federation_client_cfg_path);
 
     let mut rng = thread_rng();
-    let ctx = secp256k1::Secp256k1::new();
+    let ctx = Secp256k1::new();
 
     let kp = KeyPair::new(&ctx, &mut rng);
 

--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use ln_gateway::{LnGateway, LnGatewayConfig};
 use minimint::config::load_from_file;
 use minimint::modules::ln::contracts::ContractId;
+use rand::rngs::OsRng;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tide::Response;
@@ -20,7 +21,7 @@ struct Opts {
 
 #[instrument(skip_all, err)]
 async fn pay_invoice(mut req: tide::Request<State>) -> tide::Result {
-    let rng = rand::rngs::OsRng::new().unwrap();
+    let rng = OsRng::new().unwrap();
     let contract_id: ContractId = req.body_json().await?;
     let State { ref gateway } = req.state();
 

--- a/minimint-api/Cargo.toml
+++ b/minimint-api/Cargo.toml
@@ -8,14 +8,13 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.58"
 async-trait = "0.1"
-bitcoin = { version = "0.28.1", features = [ "rand", "serde" ] }
+bitcoin = { version = "0.28.1", features = [ "rand", "serde", "use-serde"] }
 bitcoin_hashes = { version = "0.10", features = ["serde"] }
 futures = "0.3.21"
 hex = "0.4.3"
 lightning-invoice = "0.16.0"
 minimint-derive = { path = "../minimint-derive" }
 rand = "0.6.0"
-secp256k1-zkp = { version = "0.6.0", features = [ "use-serde", "bitcoin_hashes", "global-context" ] }
 serde = { version = "1.0.118", features = [ "derive" ] }
 serde_json = "1.0.79"
 sled = "0.34"

--- a/minimint-api/src/encoding/btc.rs
+++ b/minimint-api/src/encoding/btc.rs
@@ -1,5 +1,5 @@
 use crate::encoding::{Decodable, DecodeError, Encodable};
-use bitcoin::hashes::Hash as BitcoinHash;
+use bitcoin_hashes::{sha256, Hash};
 use std::io::Error;
 
 macro_rules! impl_encode_decode_bridge {
@@ -65,34 +65,31 @@ impl Decodable for bitcoin::Address {
     }
 }
 
-impl Encodable for bitcoin::hashes::sha256::Hash {
+impl Encodable for sha256::Hash {
     fn consensus_encode<W: std::io::Write>(&self, writer: W) -> Result<usize, Error> {
         self.into_inner().consensus_encode(writer)
     }
 }
 
-impl Decodable for bitcoin::hashes::sha256::Hash {
+impl Decodable for sha256::Hash {
     fn consensus_decode<D: std::io::Read>(d: D) -> Result<Self, DecodeError> {
-        Ok(bitcoin::hashes::sha256::Hash::from_inner(
-            Decodable::consensus_decode(d)?,
-        ))
+        Ok(sha256::Hash::from_inner(Decodable::consensus_decode(d)?))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::encoding::{Decodable, Encodable};
-    use bitcoin::hashes::Hash as BitcoinHash;
+    use bitcoin_hashes::{sha256, Hash};
     use std::io::Cursor;
     use std::str::FromStr;
 
     #[test_log::test]
     fn sha256_roundtrip() {
-        let hash = bitcoin::hashes::sha256::Hash::hash(b"Hello world!");
+        let hash = sha256::Hash::hash(b"Hello world!");
         let mut encoded = Vec::new();
         hash.consensus_encode(&mut encoded).unwrap();
-        let hash_decoded =
-            bitcoin::hashes::sha256::Hash::consensus_decode(Cursor::new(encoded)).unwrap();
+        let hash_decoded = sha256::Hash::consensus_decode(Cursor::new(encoded)).unwrap();
         assert_eq!(hash, hash_decoded);
     }
 

--- a/minimint-api/src/encoding/secp256k1.rs
+++ b/minimint-api/src/encoding/secp256k1.rs
@@ -1,8 +1,13 @@
 use crate::encoding::{Decodable, DecodeError, Encodable};
-use secp256k1_zkp::ecdsa::Signature;
+use bitcoin::secp256k1::{
+    constants,
+    ecdsa::{self, Signature},
+    global, schnorr, XOnlyPublicKey,
+};
+
 use std::io::{Error, Read, Write};
 
-impl Encodable for secp256k1_zkp::ecdsa::Signature {
+impl Encodable for ecdsa::Signature {
     fn consensus_encode<W: std::io::Write>(&self, mut writer: W) -> Result<usize, std::io::Error> {
         let bytes = self.serialize_compact();
         writer.write_all(&bytes)?;
@@ -10,7 +15,7 @@ impl Encodable for secp256k1_zkp::ecdsa::Signature {
     }
 }
 
-impl Decodable for secp256k1_zkp::ecdsa::Signature {
+impl Decodable for ecdsa::Signature {
     fn consensus_decode<D: std::io::Read>(mut d: D) -> Result<Self, DecodeError> {
         let mut bytes = [0u8; 64];
         d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
@@ -18,7 +23,7 @@ impl Decodable for secp256k1_zkp::ecdsa::Signature {
     }
 }
 
-impl Encodable for secp256k1_zkp::XOnlyPublicKey {
+impl Encodable for XOnlyPublicKey {
     fn consensus_encode<W: std::io::Write>(&self, mut writer: W) -> Result<usize, std::io::Error> {
         let bytes = self.serialize();
         writer.write_all(&bytes[..])?;
@@ -26,31 +31,28 @@ impl Encodable for secp256k1_zkp::XOnlyPublicKey {
     }
 }
 
-impl Decodable for secp256k1_zkp::XOnlyPublicKey {
+impl Decodable for XOnlyPublicKey {
     fn consensus_decode<D: std::io::Read>(mut d: D) -> Result<Self, DecodeError> {
         let mut bytes = [0u8; 32];
         d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
-        secp256k1_zkp::XOnlyPublicKey::from_slice(&bytes[..]).map_err(DecodeError::from_err)
+        XOnlyPublicKey::from_slice(&bytes[..]).map_err(DecodeError::from_err)
     }
 }
 
-impl Encodable for secp256k1_zkp::schnorr::Signature {
+impl Encodable for schnorr::Signature {
     fn consensus_encode<W: std::io::Write>(&self, mut writer: W) -> Result<usize, std::io::Error> {
         let bytes = &self[..];
-        assert_eq!(
-            bytes.len(),
-            secp256k1_zkp::constants::SCHNORR_SIGNATURE_SIZE
-        );
+        assert_eq!(bytes.len(), constants::SCHNORR_SIGNATURE_SIZE);
         writer.write_all(bytes)?;
-        Ok(secp256k1_zkp::constants::SCHNORR_SIGNATURE_SIZE)
+        Ok(constants::SCHNORR_SIGNATURE_SIZE)
     }
 }
 
-impl Decodable for secp256k1_zkp::schnorr::Signature {
+impl Decodable for schnorr::Signature {
     fn consensus_decode<D: std::io::Read>(mut d: D) -> Result<Self, DecodeError> {
-        let mut bytes = [0u8; secp256k1_zkp::constants::SCHNORR_SIGNATURE_SIZE];
+        let mut bytes = [0u8; constants::SCHNORR_SIGNATURE_SIZE];
         d.read_exact(&mut bytes).map_err(DecodeError::from_err)?;
-        secp256k1_zkp::schnorr::Signature::from_slice(&bytes).map_err(DecodeError::from_err)
+        schnorr::Signature::from_slice(&bytes).map_err(DecodeError::from_err)
     }
 }
 
@@ -63,7 +65,7 @@ impl Encodable for bitcoin::KeyPair {
 impl Decodable for bitcoin::KeyPair {
     fn consensus_decode<D: Read>(d: D) -> Result<Self, DecodeError> {
         let sec_bytes = <[u8; 32]>::consensus_decode(d)?;
-        Self::from_seckey_slice(secp256k1_zkp::global::SECP256K1, &sec_bytes) // FIXME: evaluate security risk of global ctx
+        Self::from_seckey_slice(global::SECP256K1, &sec_bytes) // FIXME: evaluate security risk of global ctx
             .map_err(DecodeError::from_err)
     }
 }
@@ -71,15 +73,16 @@ impl Decodable for bitcoin::KeyPair {
 #[cfg(test)]
 mod tests {
     use super::super::tests::test_roundtrip;
-    use secp256k1_zkp::hashes::Hash as BitcoinHash;
-    use secp256k1_zkp::Message;
+    use bitcoin::secp256k1::{global, Message, Secp256k1};
+    use bitcoin_hashes::{sha256, Hash};
+    use rand::rngs::OsRng;
 
     #[test_log::test]
     fn test_ecdsa_sig() {
-        let ctx = secp256k1_zkp::Secp256k1::new();
+        let ctx = Secp256k1::new();
         let (sk, _pk) = ctx.generate_keypair(&mut rand::thread_rng());
         let sig = ctx.sign_ecdsa(
-            &Message::from_hashed_data::<secp256k1_zkp::hashes::sha256::Hash>(b"Hello World!"),
+            &Message::from_hashed_data::<sha256::Hash>(b"Hello World!"),
             &sk,
         );
 
@@ -88,16 +91,13 @@ mod tests {
 
     #[test_log::test]
     fn test_schnorr_pub_key() {
-        let ctx = secp256k1_zkp::global::SECP256K1;
-        let mut rng = rand::rngs::OsRng::new().unwrap();
+        let ctx = global::SECP256K1;
+        let mut rng = OsRng::new().unwrap();
         let sec_key = bitcoin::KeyPair::new(ctx, &mut rng);
         let pub_key = sec_key.public_key();
         test_roundtrip(pub_key);
 
-        let sig = ctx.sign_schnorr(
-            &secp256k1_zkp::hashes::sha256::Hash::hash(b"Hello World!").into(),
-            &sec_key,
-        );
+        let sig = ctx.sign_schnorr(&sha256::Hash::hash(b"Hello World!").into(), &sec_key);
 
         test_roundtrip(sig);
     }

--- a/minimint-api/src/module/mod.rs
+++ b/minimint-api/src/module/mod.rs
@@ -5,10 +5,9 @@ pub mod testing;
 use crate::db::batch::BatchTx;
 use crate::{Amount, PeerId};
 use async_trait::async_trait;
+use bitcoin::secp256k1::{rand::RngCore, XOnlyPublicKey};
 use futures::future::BoxFuture;
 use rand::CryptoRng;
-use secp256k1_zkp::rand::RngCore;
-use secp256k1_zkp::XOnlyPublicKey;
 use std::collections::HashSet;
 
 use crate::module::audit::Audit;

--- a/minimint-api/src/module/testing.rs
+++ b/minimint-api/src/module/testing.rs
@@ -1,4 +1,6 @@
 use async_trait::async_trait;
+use bitcoin::secp256k1::XOnlyPublicKey;
+use rand::rngs::OsRng;
 
 use crate::config::GenerateConfig;
 use crate::db::batch::DbBatch;
@@ -24,7 +26,7 @@ pub struct FakeFed<M, CC> {
 #[derive(Debug, PartialEq, Eq)]
 pub struct TestInputMeta {
     pub amount: Amount,
-    pub keys: Vec<secp256k1_zkp::XOnlyPublicKey>,
+    pub keys: Vec<XOnlyPublicKey>,
 }
 
 impl<M, CC> FakeFed<M, CC>
@@ -49,7 +51,7 @@ where
             .map(|idx| PeerId::from(idx as u16))
             .collect::<Vec<_>>();
         let (server_cfg, client_cfg) =
-            C::trusted_dealer_gen(&peers, max_evil, params, rand::rngs::OsRng::new().unwrap());
+            C::trusted_dealer_gen(&peers, max_evil, params, OsRng::new().unwrap());
 
         let mut members = vec![];
         for (peer, cfg) in server_cfg {
@@ -99,7 +101,7 @@ where
     ) where
         <M as FederationModule>::TxInput: Send + Sync,
     {
-        let mut rng = rand::rngs::OsRng::new().unwrap();
+        let mut rng = OsRng::new().unwrap();
         let fake_ic = FakeInterconnect::new_block_height_responder(self.block_height.clone());
 
         // TODO: only include some of the proposals for realism

--- a/minimint-core/src/transaction.rs
+++ b/minimint-core/src/transaction.rs
@@ -1,6 +1,6 @@
 use crate::config::FeeConsensus;
 use bitcoin::hashes::Hash as BitcoinHash;
-use bitcoin::XOnlyPublicKey;
+use bitcoin::secp256k1::XOnlyPublicKey;
 use minimint_api::encoding::{Decodable, Encodable};
 use minimint_api::{Amount, FederationModule, TransactionId};
 use rand::Rng;

--- a/minimint/Cargo.toml
+++ b/minimint/Cargo.toml
@@ -29,7 +29,7 @@ opentelemetry = { version = "0.17.0", optional = true }
 opentelemetry-jaeger = { version = "0.16.0", optional = true }
 rand = "0.6.5"
 rayon = "1.5.0"
-secp256k1-zkp = { version = "0.6.0", features = [ "global-context", "bitcoin_hashes" ] }
+secp256k1 = { version = "0.22.1", features = [ "global-context", "bitcoin_hashes" ] }
 serde = { version = "1.0.118", features = [ "derive" ] }
 serde_json = "1.0.61"
 sha3 = "0.9.1"

--- a/minimint/src/consensus/interconnect.rs
+++ b/minimint/src/consensus/interconnect.rs
@@ -5,7 +5,7 @@ use minimint_api::module::interconnect::ModuleInterconect;
 use minimint_api::module::ApiError;
 use minimint_api::FederationModule;
 use rand::CryptoRng;
-use secp256k1_zkp::rand::RngCore;
+use secp256k1::rand::RngCore;
 use serde_json::Value;
 
 pub struct MinimintInterconnect<'a, R: RngCore + CryptoRng> {

--- a/minimint/src/lib.rs
+++ b/minimint/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 
 use hbbft::honey_badger::{HoneyBadger, Message};
 use hbbft::NetworkInfo;
+use minimint_core::modules::mint::Mint;
 use rand::rngs::OsRng;
 use rand::{CryptoRng, RngCore};
 use tokio::sync::Notify;
@@ -87,7 +88,7 @@ impl MinimintServer {
         let threshold = cfg.peers.len() - cfg.max_faulty();
 
         let mint =
-            minimint_core::modules::mint::Mint::new(cfg.mint.clone(), threshold, database.clone());
+            Mint::new(cfg.mint.clone(), threshold, database.clone());
 
         let wallet = Wallet::new_with_bitcoind(cfg.wallet.clone(), database.clone(), bitcoind)
             .await

--- a/modules/minimint-ln/src/contracts/account.rs
+++ b/modules/minimint-ln/src/contracts/account.rs
@@ -1,12 +1,13 @@
 use crate::contracts::{ContractId, IdentifyableContract};
-use bitcoin_hashes::Hash as BitcoinHash;
+use bitcoin_hashes::Hash;
 use minimint_api::encoding::{Decodable, Encodable};
+use secp256k1::XOnlyPublicKey;
 use serde::{Deserialize, Serialize};
 
 /// A generic contract to hold money in a pub key locked account
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct AccountContract {
-    pub key: secp256k1::XOnlyPublicKey,
+    pub key: XOnlyPublicKey,
 }
 
 impl IdentifyableContract for AccountContract {

--- a/modules/minimint-ln/src/contracts/incoming.rs
+++ b/modules/minimint-ln/src/contracts/incoming.rs
@@ -4,6 +4,7 @@ use bitcoin_hashes::Hash as BitcoinHash;
 use bitcoin_hashes::{borrow_slice_impl, hash_newtype, hex_fmt_impl, index_impl, serde_impl};
 use minimint_api::encoding::{Decodable, DecodeError, Encodable};
 use minimint_api::OutPoint;
+use secp256k1::XOnlyPublicKey;
 use serde::{Deserialize, Serialize};
 use std::io::Error;
 
@@ -56,7 +57,7 @@ pub struct IncomingContract {
     /// the contract, allowing the offer creator to redeem their money.
     pub decrypted_preimage: DecryptedPreimage,
     /// Key that can unlock contract in case the decrypted preimage was invalid
-    pub gateway_key: secp256k1::XOnlyPublicKey,
+    pub gateway_key: XOnlyPublicKey,
 }
 
 /// The funded version of an [`IncomingContract`] contains the [`OutPoint`] of it's creation. Since
@@ -93,7 +94,7 @@ hash_newtype!(
 /// A preimage in the context of incoming contracts. In this context it is a public key chosen
 /// by the creator of the [`IncomingContractOffer`].
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
-pub struct Preimage(pub secp256k1::XOnlyPublicKey);
+pub struct Preimage(pub XOnlyPublicKey);
 
 /// Threshold-encrypted [`Preimage`]
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]

--- a/modules/minimint-ln/src/contracts/outgoing.rs
+++ b/modules/minimint-ln/src/contracts/outgoing.rs
@@ -1,6 +1,7 @@
 use crate::contracts::{ContractId, IdentifyableContract};
-use bitcoin_hashes::Hash as BitcoinHash;
+use bitcoin_hashes::{sha256, Hash};
 use minimint_api::encoding::{Decodable, Encodable};
+use secp256k1::XOnlyPublicKey;
 use serde::{Deserialize, Serialize};
 
 /// Specialized smart contract for outgoing payments.
@@ -11,13 +12,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct OutgoingContract {
     /// Hash that can be used to spend the output before the timelock expires
-    pub hash: bitcoin_hashes::sha256::Hash,
+    pub hash: sha256::Hash,
     /// Public key of the LN gateway allowed to claim the HTLC before the timelock expires
-    pub gateway_key: secp256k1::XOnlyPublicKey,
+    pub gateway_key: XOnlyPublicKey,
     /// Block height at which the money will be spendable by the pubkey
     pub timelock: u32,
     /// Public key of the user that can claim the money back after the timelock expires
-    pub user_key: secp256k1::XOnlyPublicKey,
+    pub user_key: XOnlyPublicKey,
     // FIXME: use pruned, privacy friendly version without description etc.
     /// Invoice containing metadata on how to obtain the preimage
     pub invoice: String,

--- a/modules/minimint-mint/src/lib.rs
+++ b/modules/minimint-mint/src/lib.rs
@@ -15,6 +15,7 @@ use minimint_api::module::ApiEndpoint;
 use minimint_api::{Amount, FederationModule, InputMeta, OutPoint, PeerId};
 use rand::{CryptoRng, RngCore};
 use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
+use secp256k1_zkp::XOnlyPublicKey;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
@@ -76,7 +77,7 @@ pub struct Coin(pub CoinNonce, pub tbs::Signature);
 /// A unique coin nonce which is also a MuSig pub key so that transactions can be signed by the
 /// spent coin's spending keys to avoid mint frontrunning.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
-pub struct CoinNonce(pub secp256k1_zkp::XOnlyPublicKey);
+pub struct CoinNonce(pub XOnlyPublicKey);
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, Encodable, Decodable)]
 pub struct BlindToken(pub tbs::BlindedMessage);
@@ -630,7 +631,7 @@ impl Coin {
     }
 
     /// Access the nonce as the public key to the spend key
-    pub fn spend_key(&self) -> &secp256k1_zkp::XOnlyPublicKey {
+    pub fn spend_key(&self) -> &XOnlyPublicKey {
         &self.0 .0
     }
 }

--- a/modules/minimint-wallet/Cargo.toml
+++ b/modules/minimint-wallet/Cargo.toml
@@ -20,7 +20,6 @@ minimint-api = { path = "../../minimint-api" }
 minimint-derive = { path = "../../minimint-derive" }
 miniscript = { version = "7.0.0", features = [ "compiler", "use-serde" ] }
 rand = "0.6.0"
-secp256k1 = { version = "0.22.1", features = [ "serde" ] }
 serde = { version = "1.0.118", features = [ "derive" ] }
 thiserror = "1.0.23"
 tokio = { version = "1.0.1", features = ["sync"], optional = true }

--- a/modules/minimint-wallet/src/config.rs
+++ b/modules/minimint-wallet/src/config.rs
@@ -1,5 +1,6 @@
 use crate::keys::CompressedPublicKey;
 use crate::{Feerate, PegInDescriptor};
+use bitcoin::secp256k1::{SecretKey, Secp256k1};
 use bitcoin::secp256k1::rand::{CryptoRng, RngCore};
 use bitcoin::Network;
 use minimint_api::config::GenerateConfig;
@@ -13,7 +14,7 @@ pub struct WalletConfig {
     pub network: Network,
     pub peg_in_descriptor: PegInDescriptor,
     pub peer_peg_in_keys: BTreeMap<PeerId, CompressedPublicKey>,
-    pub peg_in_key: secp256k1::SecretKey,
+    pub peg_in_key: SecretKey,
     pub finalty_delay: u32,
     pub default_fee: Feerate,
     pub btc_rpc_address: String,
@@ -37,7 +38,7 @@ impl GenerateConfig for WalletConfig {
         _params: &Self::Params,
         mut rng: impl RngCore + CryptoRng,
     ) -> (BTreeMap<PeerId, Self>, Self::ClientConfig) {
-        let secp = secp256k1::Secp256k1::new();
+        let secp = Secp256k1::new();
 
         let btc_pegin_keys = peers
             .iter()

--- a/modules/minimint-wallet/src/db.rs
+++ b/modules/minimint-wallet/src/db.rs
@@ -1,10 +1,10 @@
 use crate::{
     PendingPegOut, PendingTransaction, RoundConsensus, SpendableUTXO, UnsignedTransaction,
 };
+use bitcoin::secp256k1::ecdsa::Signature;
 use bitcoin::{BlockHash, OutPoint, Txid};
 use minimint_api::db::DatabaseKeyPrefixConst;
 use minimint_api::encoding::{Decodable, Encodable};
-use secp256k1::ecdsa::Signature;
 
 const DB_PREFIX_BLOCK_HASH: u8 = 0x30;
 const DB_PREFIX_UTXO: u8 = 0x31;

--- a/modules/minimint-wallet/src/keys.rs
+++ b/modules/minimint-wallet/src/keys.rs
@@ -1,18 +1,17 @@
 use crate::tweakable::{Contract, Tweakable};
 use bitcoin::hashes::Hash;
-use bitcoin::secp256k1::{Secp256k1, Verification};
-use bitcoin::PublicKey;
+use bitcoin::secp256k1::{PublicKey, Secp256k1, Verification};
 use miniscript::{MiniscriptKey, ToPublicKey};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct CompressedPublicKey {
-    pub key: secp256k1::PublicKey,
+    pub key: PublicKey,
 }
 
 impl CompressedPublicKey {
-    pub fn new(key: secp256k1::PublicKey) -> Self {
+    pub fn new(key: PublicKey) -> Self {
         CompressedPublicKey { key }
     }
 }
@@ -30,11 +29,8 @@ impl MiniscriptKey for CompressedPublicKey {
 }
 
 impl ToPublicKey for CompressedPublicKey {
-    fn to_public_key(&self) -> PublicKey {
-        PublicKey {
-            compressed: true,
-            inner: self.key,
-        }
+    fn to_public_key(&self) -> bitcoin::PublicKey {
+        self.key.to_public_key()
     }
 
     fn hash_to_hash160(hash: &Self::Hash) -> bitcoin::hashes::hash160::Hash {
@@ -49,11 +45,11 @@ impl std::fmt::Display for CompressedPublicKey {
 }
 
 impl FromStr for CompressedPublicKey {
-    type Err = secp256k1::Error;
+    type Err = bitcoin::secp256k1::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(CompressedPublicKey {
-            key: secp256k1::PublicKey::from_str(s)?,
+            key: PublicKey::from_str(s)?,
         })
     }
 }
@@ -66,11 +62,14 @@ impl Tweakable for CompressedPublicKey {
     }
 }
 
-impl From<CompressedPublicKey> for bitcoin::PublicKey {
+impl From<CompressedPublicKey> for PublicKey {
     fn from(key: CompressedPublicKey) -> Self {
-        bitcoin::PublicKey {
-            compressed: true,
-            inner: key.key,
-        }
+        key.key
+    }
+}
+
+impl Into<bitcoin::PublicKey> for CompressedPublicKey {
+    fn into(self) -> bitcoin::PublicKey {
+        self.key.to_public_key()
     }
 }

--- a/modules/minimint-wallet/src/tweakable.rs
+++ b/modules/minimint-wallet/src/tweakable.rs
@@ -1,5 +1,5 @@
-use bitcoin::hashes::{sha256, Hash as BitcoinHash, Hmac, HmacEngine};
-use secp256k1::{Secp256k1, Verification};
+use bitcoin::hashes::{sha256, Hash, Hmac, HmacEngine};
+use bitcoin::secp256k1::{PublicKey, Secp256k1, Verification, XOnlyPublicKey};
 use std::io::Write;
 
 /// An object that can be used as a ricardian contract to tweak a key
@@ -14,7 +14,7 @@ pub trait Tweakable {
     fn tweak<Ctx: Verification, Ctr: Contract>(&self, tweak: &Ctr, secp: &Secp256k1<Ctx>) -> Self;
 }
 
-impl Tweakable for secp256k1::PublicKey {
+impl Tweakable for PublicKey {
     fn tweak<Ctx: Verification, Ctr: Contract>(&self, tweak: &Ctr, secp: &Secp256k1<Ctx>) -> Self {
         let mut hasher = HmacEngine::<sha256::Hash>::new(&self.serialize()[..]);
         tweak.encode(&mut hasher).expect("hashing is infallible");
@@ -28,7 +28,7 @@ impl Tweakable for secp256k1::PublicKey {
     }
 }
 
-impl Contract for secp256k1::PublicKey {
+impl Contract for PublicKey {
     fn encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         writer.write_all(&self.serialize())
     }
@@ -46,7 +46,7 @@ impl Contract for [u8; 32] {
     }
 }
 
-impl Contract for secp256k1::XOnlyPublicKey {
+impl Contract for XOnlyPublicKey {
     fn encode<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         writer.write_all(&self.serialize()[..])
     }

--- a/modules/minimint-wallet/src/txoproof.rs
+++ b/modules/minimint-wallet/src/txoproof.rs
@@ -1,10 +1,10 @@
 use crate::keys::CompressedPublicKey;
 use crate::tweakable::{Contract, Tweakable};
+use bitcoin::secp256k1::{Secp256k1, Verification, XOnlyPublicKey};
 use bitcoin::util::merkleblock::PartialMerkleTree;
 use bitcoin::{BlockHash, BlockHeader, OutPoint, Transaction, Txid};
 use minimint_api::encoding::{Decodable, DecodeError, Encodable};
 use miniscript::{Descriptor, DescriptorTrait, TranslatePk2};
-use secp256k1::{Secp256k1, Verification};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::hash::Hash;
@@ -23,7 +23,7 @@ pub struct PegInProof {
     transaction: Transaction,
     // Check that the idx is in range
     output_idx: u32,
-    tweak_contract_key: secp256k1::XOnlyPublicKey,
+    tweak_contract_key: XOnlyPublicKey,
 }
 
 #[derive(Clone, Debug)]
@@ -91,7 +91,7 @@ impl PegInProof {
         txout_proof: TxOutProof,
         transaction: Transaction,
         output_idx: u32,
-        tweak_contract_key: secp256k1::XOnlyPublicKey,
+        tweak_contract_key: XOnlyPublicKey,
     ) -> Result<PegInProof, PegInProofError> {
         // TODO: remove redundancy with serde validation
         if !txout_proof.contains_tx(transaction.txid()) {
@@ -143,11 +143,11 @@ impl PegInProof {
         self.txout_proof.block()
     }
 
-    pub fn tweak_contract_key(&self) -> &secp256k1::XOnlyPublicKey {
+    pub fn tweak_contract_key(&self) -> &XOnlyPublicKey {
         &self.tweak_contract_key
     }
 
-    pub fn identity(&self) -> (secp256k1::XOnlyPublicKey, bitcoin::Txid) {
+    pub fn identity(&self) -> (XOnlyPublicKey, bitcoin::Txid) {
         (self.tweak_contract_key, self.transaction.txid())
     }
 
@@ -258,7 +258,7 @@ impl Decodable for PegInProof {
             txout_proof: TxOutProof::consensus_decode(&mut d)?,
             transaction: Transaction::consensus_decode(&mut d)?,
             output_idx: u32::consensus_decode(&mut d)?,
-            tweak_contract_key: secp256k1::XOnlyPublicKey::consensus_decode(&mut d)?,
+            tweak_contract_key: XOnlyPublicKey::consensus_decode(&mut d)?,
         };
 
         validate_peg_in_proof(&slf).map_err(DecodeError::from_err)?;


### PR DESCRIPTION
Went through and cleaned up some of our dependency usage, lifting as much as I could up into the use statements. In the process I standardized to using the keys in bitcoin::secp256k1::{PublicKey, XOnlyPublicKey}, if we use bitcoin::PublicKey for example then we have to import the bitcoin crate wherever we want to use it instead of just pulling in secp. The only crate that strictly requires using bitcoin::PublicKey right now is miniscript so in the wallet we can convert from the secp -> bitcoin::PublicKey using kp.to_public_key()

Also was able to remove secp256k1-zkp from client-lib, minimint-api, and minimint Cargo.tomls. All the functions and structs they were using have been integrated into secp256k1. I also removed secp256k1 as a dependency where we already were using the bitcoin crate.