### PR TITLE
Move all client DB keys into 0x2 namespace

### DIFF
--- a/client/client-lib/src/ln/db.rs
+++ b/client/client-lib/src/ln/db.rs
@@ -2,11 +2,15 @@ use crate::ln::outgoing::OutgoingContractData;
 use minimint_api::db::DatabaseKeyPrefixConst;
 use minimint_api::encoding::{Decodable, Encodable};
 use minimint_core::modules::ln::contracts::ContractId;
+use minimint_core::transaction::Transaction;
 
 use super::incoming::ConfirmedInvoice;
+use super::outgoing::OutgoingContractAccount;
 
-const DB_PREFIX_OUTGOING_PAYMENT: u8 = 0x40;
-const DB_PREFIX_CONFIRMED_INVOICE: u8 = 0x45;
+const DB_PREFIX_OUTGOING_PAYMENT: u8 = 0x23;
+const DB_PREFIX_OUTGOING_PAYMENT_CLAIM: u8 = 0x24;
+const DB_PREFIX_OUTGOING_CONTRACT_ACCOUNT: u8 = 0x25;
+const DB_PREFIX_CONFIRMED_INVOICE: u8 = 0x26;
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct OutgoingPaymentKey(pub ContractId);
@@ -24,6 +28,42 @@ impl DatabaseKeyPrefixConst for OutgoingPaymentKeyPrefix {
     const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_PAYMENT;
     type Key = OutgoingPaymentKey;
     type Value = OutgoingContractData;
+}
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct OutgoingPaymentClaimKey(pub ContractId);
+
+impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKey {
+    const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_PAYMENT_CLAIM;
+    type Key = Self;
+    type Value = Transaction;
+}
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct OutgoingPaymentClaimKeyPrefix;
+
+impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKeyPrefix {
+    const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_PAYMENT_CLAIM;
+    type Key = OutgoingPaymentClaimKey;
+    type Value = Transaction;
+}
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct OutgoingContractAccountKey(pub ContractId);
+
+impl DatabaseKeyPrefixConst for OutgoingContractAccountKey {
+    const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_CONTRACT_ACCOUNT;
+    type Key = Self;
+    type Value = OutgoingContractAccount;
+}
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct OutgoingContractAccountKeyPrefix;
+
+impl DatabaseKeyPrefixConst for OutgoingContractAccountKeyPrefix {
+    const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_CONTRACT_ACCOUNT;
+    type Key = OutgoingContractAccountKey;
+    type Value = OutgoingContractAccount;
 }
 
 #[derive(Debug, Encodable, Decodable)]

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -1,4 +1,5 @@
-mod db;
+// TODO: once user and mint client are merged, make this private again
+pub mod db;
 pub mod gateway;
 pub mod incoming;
 pub mod outgoing;

--- a/docs/database.md
+++ b/docs/database.md
@@ -49,17 +49,19 @@ The Database is split into different key spaces based on prefixing that can be u
 
 | Name                             | Prefix | Key                                 | Value                        |
 |----------------------------------|--------|-------------------------------------|------------------------------|
-| Accounts                         | 0x40   | contract id (sha256)                | `ContractAccount`            |
-| Offers                           | 0x41   | payment hash (sha256)               | `IncomingContractOffer`      |
-| Our Decryption Shares            | 0x42   | contract id (sha256)                | `DecryptionShare`            |
-| Consensus Decryption Shares      | 0x43   | contract id (sha256), peer id (u16) | `DecryptionShare`            |
-| Contract Update (output outcome) | 0x44   | out point (sha256, out idx)         | `minimint_ln::OutputOutcome` |
-| Confirmed Invoice                | 0x45   | contract id (sha256 payment hash)   | `ConfirmedInvoice`           |
+| Offers                           | `0x41` | payment hash (sha256)               | `IncomingContractOffer`      |
+| Our Decryption Shares            | `0x42` | contract id (sha256)                | `DecryptionShare`            |
+| Consensus Decryption Shares      | `0x43` | contract id (sha256), peer id (u16) | `DecryptionShare`            |
+| Contract Update (output outcome) | `0x44` | out point (sha256, out idx)         | `minimint_ln::OutputOutcome` |
 
 ## Client DB Layout
 
-| Name      | Prefix | Key                                | Value                        |
-|-----------|--------|------------------------------------|------------------------------|
-| Coins     | `0x20`   | amount (8 bytes), nonce (32 bytes) | serialized `SpendableCoin`   |
-| Issuances | `0x21`   | issuance_id (32 bytes)             | serialized `IssuanceRequest` |
-| Peg-Ins   | `0x22`   | secret contract key (32 bytes)     | none                         |
+| Name                      | Prefix | Key                                | Value                        |
+|---------------------------|--------|------------------------------------|------------------------------|
+| Coins                     | `0x20` | amount (8 bytes), nonce (32 bytes) | serialized `SpendableCoin`   |
+| Issuances                 | `0x21` | issuance_id (32 bytes)             | serialized `IssuanceRequest` |
+| Peg-Ins                   | `0x22` | secret contract key (32 bytes)     | none                         |
+| Outoing Payment           | `0x23` | contract id (sha256 payment hash)  | `OutgoingContractData`       |
+| Outgoing Payment Claim    | `0x24` | contract id (sha256)               | `Transaction`                |
+| Outgoing Contract Account | `0x25` | contract id (sha256)               | `OutgoingContractAccount`    |
+| Confirmed Invoice         | `0x26` | contract id (sha256 payment hash)  | `ConfirmedInvoice`           |


### PR DESCRIPTION
Had to make ln client's db module public to do this. We should make it private again once the user and gateway clients are unified.

Removing db keys from the `gateway.rs` is a step towards https://github.com/fedimint/minimint/issues/236