### PR TITLE
dev.sh script to setup full dev environment in nix

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Setup full dev environment
+
+source ./scripts/build.sh
+source ./scripts/setup-tests.sh
+./scripts/start-fed.sh
+./scripts/pegin.sh 0.0001


### PR DESCRIPTION
I found this little script very useful, myself. You get a full dev environment with:

```
$ nix-shell
[nix-shell]$ source scripts/dev.sh
```

Should it take arguments? Should we use this in the `README`?