### PR TITLE
gateway: Enable cln plugin reloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
 [[package]]
 name = "cln-plugin"
 version = "0.1.0"
-source = "git+https://github.com/ElementsProject/lightning?rev=e6442d7#e6442d798ef24e1f868ca6003cad6e20a4d8dd5e"
+source = "git+https://github.com/ElementsProject/lightning?rev=42783aa#42783aaa928da79e1295dcdc53123a66cb2433cc"
 dependencies = [
  "anyhow",
  "bytes",
@@ -695,14 +695,13 @@ dependencies = [
 [[package]]
 name = "cln-rpc"
 version = "0.1.0"
-source = "git+https://github.com/ElementsProject/lightning?rev=e6442d7#e6442d798ef24e1f868ca6003cad6e20a4d8dd5e"
+source = "git+https://github.com/ElementsProject/lightning?rev=42783aa#42783aaa928da79e1295dcdc53123a66cb2433cc"
 dependencies = [
  "anyhow",
  "bytes",
  "futures-util",
  "hex",
  "log",
- "native-tls",
  "serde",
  "serde_json",
  "tokio",
@@ -1073,21 +1072,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2247,24 +2231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2326,59 +2292,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2 1.0.40",
- "quote 1.0.20",
- "syn 1.0.98",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-src"
-version = "111.22.0+1.1.1q"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
-dependencies = [
- "autocfg 1.1.0",
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -2565,12 +2482,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "polling"
@@ -4155,12 +4066,6 @@ dependencies = [
  "sval",
  "version_check",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ resolver = "2"
 [patch.crates-io]
 bitcoin_hashes = { version = "0.10.0", git = 'https://github.com/fedimint/bitcoin_hashes', branch = 'minimint' }
 secp256k1-zkp = { git = "https://github.com/fedimint/rust-secp256k1-zkp/", branch = "sanket-pr" }
-cln-plugin = { git = "https://github.com/ElementsProject/lightning", rev = "e6442d7" }
-cln-rpc = { git = "https://github.com/ElementsProject/lightning", rev = "e6442d7" }
+cln-plugin = { git = "https://github.com/ElementsProject/lightning", rev = "42783aa" }
+cln-rpc = { git = "https://github.com/ElementsProject/lightning", rev = "42783aa" }

--- a/ln-gateway/src/bin/ln_gateway.rs
+++ b/ln-gateway/src/bin/ln_gateway.rs
@@ -155,6 +155,7 @@ async fn main() -> Result<(), Error> {
             });
             handle.await?
         })
+        .dynamic() // Allow reloading the plugin
         .start()
         .await?
     {

--- a/scripts/gw-reload.sh
+++ b/scripts/gw-reload.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Reload core-lightning gateway plugin
+
+set -euo pipefail
+
+cargo build --release --bin ln_gateway
+$LN1 plugin stop ln_gateway &> /dev/null
+$LN1 -k plugin subcommand=start plugin=$BIN_DIR/ln_gateway minimint-cfg=$CFG_DIR &> /dev/null
+
+echo "Gateway plugin reloaded"


### PR DESCRIPTION
- Update cln_plugin dependency to include https://github.com/ElementsProject/lightning/pull/5397
- Add a script to automatically re-build gateway plugin and tell cln to reload it.

Without this PR, testing any change to the gateway via CLI is a multi-step process.