### PR TITLE
adds latency-test.sh to GH actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,6 +61,22 @@ jobs:
         with:
           command: build
           args: --target wasm32-unknown-unknown --package mint-client
+  build_and_latency_test:
+    name: Latency Tests
+    runs-on: buildjet-8vcpu-ubuntu-2004
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
+      - uses: cachix/install-nix-action@v15
+        with:
+          nix_path: nixpkgs=channel:nixos-22.05
+      - uses: cachix/cachix-action@v10
+        with:
+          name: fedimint
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Latency Tests with nix-shell
+        run: nix-shell --command ./scripts/latency-test.sh
   build_and_cli_test:
     name: CLI Tests
     runs-on: buildjet-8vcpu-ubuntu-2004
@@ -75,7 +91,7 @@ jobs:
         with:
           name: fedimint
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - name: Integration Tests with nix-shell
+      - name: CLI Tests with nix-shell
         run: nix-shell --command ./scripts/cli-test.sh
   build_and_integration_test:
     name: Integration Tests

--- a/scripts/latency-test.sh
+++ b/scripts/latency-test.sh
@@ -3,6 +3,7 @@
 
 set -eu
 FED_SIZE=${1:-4}
+ITERATIONS=${2:-5}
 export RUST_LOG=error,ln_gateway=off
 export PEG_IN_AMOUNT=0.00099999
 
@@ -15,16 +16,18 @@ source ./scripts/setup-tests.sh
 echo "Running with fed size $FED_SIZE"
 
 # reissue
-time for i in {1..10}
+time1=$(date +%s.%N)
+for i in $( seq 1 $ITERATIONS )
 do
   echo "REISSUE $i"
   TOKENS=$($MINT_CLIENT spend 1000)
   $MINT_CLIENT reissue $TOKENS
   $MINT_CLIENT fetch
 done
+time2=$(date +%s.%N)
 
 ## outgoing lightning
-time for i in {1..10}
+for i in $( seq 1 $ITERATIONS )
 do
   echo "LN SEND $i"
   LABEL=test$RANDOM$RANDOM
@@ -35,9 +38,10 @@ do
   echo "RESULT $INVOICE_STATUS"
   [[ "$INVOICE_STATUS" = "paid" ]]
 done
+time3=$(date +%s.%N)
 
 ## incoming lightning
-time for i in {1..10}
+for i in $( seq 1 $ITERATIONS )
 do
   echo "LN RECEIVE $i"
   INVOICE="$($MINT_CLIENT ln-invoice 500000 '$RANDOM')"
@@ -46,3 +50,17 @@ do
   echo "RESULT $INVOICE_STATUS"
   [[ "$INVOICE_STATUS" = "complete" ]]
 done
+time4=$(date +%s.%N)
+
+# TODO running outputs spurious error logs
+REISSUE=$(echo "scale=3; ($time2 - $time1) / $ITERATIONS" | bc)
+echo "AVG REISSUE TIME: $REISSUE seconds"
+LN_SEND=$(echo "scale=3; ($time3 - $time2) / $ITERATIONS" | bc)
+echo "AVG LN SEND TIME: $LN_SEND seconds"
+LN_RECEIVE=$(echo "scale=3; ($time4 - $time3) / $ITERATIONS" | bc)
+echo "AVG LN RECEIVE TIME: $LN_RECEIVE seconds"
+
+# Assert that avg runtimes are under 5 sec
+[[ $(echo "$REISSUE < 5" | bc -l) = 1 ]]
+[[ $(echo "$LN_SEND < 5" | bc -l) = 1 ]]
+[[ $(echo "$LN_RECEIVE < 5" | bc -l) = 1 ]]

--- a/scripts/pegin.sh
+++ b/scripts/pegin.sh
@@ -23,7 +23,8 @@ $BTC_CLIENT generatetoaddress 11 "$($BTC_CLIENT getnewaddress)"
 function await_block_sync() {
   EXPECTED_BLOCK_HEIGHT="$(( $($BTC_CLIENT getblockchaininfo | jq -r '.blocks') - $CONFIRMATION_TIME ))"
   for ((ID=0; ID<FED_SIZE; ID++)); do
-    MINT_API_URL="ws://127.0.0.1:500$ID"
+    PORT=$(echo "5000 + $ID" | bc)
+    MINT_API_URL="ws://127.0.0.1:$PORT"
     until [ "$($MINT_RPC_CLIENT $MINT_API_URL '/wallet/block_height')" == "$EXPECTED_BLOCK_HEIGHT" ]; do
       sleep $POLL_INTERVAL
     done


### PR DESCRIPTION
To ensure that no change dramatically increases the latency of an action and to check for failures from hitting the API repeatedly I'd like to add `latency-test.sh` to the GH actions.

Also this change will support fed sizes up to 20 and logs timing better:
```
# FED_SIZE=20
AVG REISSUE TIME: 2.801 seconds
AVG LN SEND TIME: 5.139 seconds
AVG LN RECEIVE TIME: 6.151 seconds
```

Surprisingly not too much slower than
```
# FED_SIZE=2
AVG REISSUE TIME: 1.068 seconds
AVG LN SEND TIME: 2.949 seconds
AVG LN RECEIVE TIME: 2.949 seconds
```