### PR TITLE
consistent bitcoin denominations

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -6,7 +6,9 @@ use minimint_core::config::load_from_file;
 use minimint_core::modules::mint::tiered::coins::Coins;
 use minimint_core::modules::wallet::txoproof::TxOutProof;
 use mint_client::mint::SpendableCoin;
-use mint_client::utils::{from_hex, parse_bitcoin_amount, parse_coins, serialize_coins};
+use mint_client::utils::{
+    from_hex, parse_bitcoin_amount, parse_coins, parse_minimint_amount, serialize_coins,
+};
 use mint_client::{Client, UserClientConfig};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -41,7 +43,10 @@ enum Command {
     },
 
     /// Prepare coins to send to a third party as a payment
-    Spend { amount: Amount },
+    Spend {
+        #[clap(parse(try_from_str = parse_minimint_amount))]
+        amount: Amount,
+    },
 
     /// Withdraw funds from the federation
     PegOut {
@@ -60,7 +65,11 @@ enum Command {
     Info,
 
     /// Create a lightning invoice to receive payment via gateway
-    LnInvoice { amount: Amount, description: String },
+    LnInvoice {
+        #[clap(parse(try_from_str = parse_minimint_amount))]
+        amount: Amount,
+        description: String,
+    },
 
     /// Wait for incoming invoice to be paid
     WaitInvoice { invoice: lightning_invoice::Invoice },

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -3,7 +3,7 @@
 
 set -euxo pipefail
 export RUST_LOG=info
-export PEG_IN_AMOUNT=0.00099999
+export PEG_IN_AMOUNT=99999
 
 source ./scripts/lib.sh
 source ./scripts/build.sh
@@ -15,7 +15,7 @@ source ./scripts/setup-tests.sh
 #### BEGIN TESTS ####
 
 # reissue
-TOKENS=$($FM_MINT_CLIENT spend 42000)
+TOKENS=$($FM_MINT_CLIENT spend '42000msat')
 $FM_MINT_CLIENT reissue $TOKENS
 $FM_MINT_CLIENT fetch
 
@@ -40,7 +40,7 @@ INVOICE_STATUS="$(echo $INVOICE_RESULT | jq -r '.status')"
 [[ "$INVOICE_STATUS" = "paid" ]]
 
 # incoming lightning
-INVOICE="$($FM_MINT_CLIENT ln-invoice 100000 'integration test')"
+INVOICE="$($FM_MINT_CLIENT ln-invoice '100000msat' 'integration test')"
 INVOICE_RESULT=$($FM_LN2 pay $INVOICE)
 INVOICE_STATUS="$(echo $INVOICE_RESULT | jq -r '.status')"
 [[ "$INVOICE_STATUS" = "complete" ]]

--- a/scripts/latency-test.sh
+++ b/scripts/latency-test.sh
@@ -5,7 +5,7 @@ set -eu
 FM_FED_SIZE=${1:-4}
 ITERATIONS=${2:-5}
 export RUST_LOG=error,ln_gateway=off
-export PEG_IN_AMOUNT=0.00099999
+export PEG_IN_AMOUNT=99999
 
 source ./scripts/build.sh $FM_FED_SIZE
 source ./scripts/setup-tests.sh
@@ -44,7 +44,7 @@ time3=$(date +%s.%N)
 for i in $( seq 1 $ITERATIONS )
 do
   echo "LN RECEIVE $i"
-  INVOICE="$($FM_MINT_CLIENT ln-invoice 500000 '$RANDOM')"
+  INVOICE="$($FM_MINT_CLIENT ln-invoice '500000msat' '$RANDOM')"
   INVOICE_RESULT=$($FM_LN2 pay $INVOICE)
   INVOICE_STATUS="$(echo $INVOICE_RESULT | jq -r '.status')"
   echo "RESULT $INVOICE_STATUS"

--- a/scripts/pegin.sh
+++ b/scripts/pegin.sh
@@ -7,6 +7,7 @@ source ./scripts/lib.sh
 
 # Let's define some shortcuts for bitcoind and the mint client
 POLL_INTERVAL=1
+# Bitcoin amount in satoshi
 PEG_IN_AMOUNT=${PEG_IN_AMOUNT:-$1}
 USE_GATEWAY=${2:-0}
 
@@ -17,7 +18,7 @@ echo "Pegging in $PEG_IN_AMOUNT"
 if [ "$USE_GATEWAY" == 1 ]; then ADDR="$($FM_LN1 -H gw-address)"; else ADDR="$($FM_MINT_CLIENT peg-in-address)"; fi
 
 # We send the amount we want to peg-in to this address
-TX_ID="$($FM_BTC_CLIENT sendtoaddress $ADDR $PEG_IN_AMOUNT)"
+TX_ID="$($FM_BTC_CLIENT sendtoaddress $ADDR 0$(echo "scale=8; $PEG_IN_AMOUNT/100000000" | bc ))"
 
 # Now we "wait" for confirmations
 $FM_BTC_CLIENT generatetoaddress 11 "$($FM_BTC_CLIENT getnewaddress)"


### PR DESCRIPTION
Addresses #237 
Maybe you think the additional `parse_minimint_amount` is overkill since we'd just change the `FromStr` impl for `Amount` but I think this is not reasonable because the default for minimint::Amount is msat so a `"1"` should always be `1msat` when parsed as a `minimint::Amount `
Also the `from_str_in` approach maybe seems weird to but since `minimint::Amount` and `bitcoin::Amount `are closley related I wouldn't call it a hack