### PR TITLE
Add clippy and rustfmt to nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,8 @@ pkgs.mkShell {
     openssl
     pkg-config
     perl
+    clippy
+    rustfmt
     rustc
     cargo
     rust-analyzer

--- a/shell.nix
+++ b/shell.nix
@@ -36,5 +36,9 @@ pkgs.mkShell {
   ];
   OPENSSL_DIR = "${pkgs.openssl.dev}";
   OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
+  shellHook = ''
+    # filter out global cargo installation so it doesn't interfere
+    PATH="$(echo $PATH | sed "s/:[^:]*\.cargo[^:]*//g")"
+  '';
 }
 


### PR DESCRIPTION
I noticed that running `which cargo-clippy` within nix-shell pointed to my system install, not the nix store.

Added another commit to filter out `~/.cargo` from path. This fixes an [issue](https://discord.com/channels/990354215060795454/992503915578933268/997436439845408869) I had where global `rustup` toolchain was leaking into nix environment and causing clippy errors.