### PR TITLE
Remove log-always feature from gateway trace dep

### DIFF
--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -25,6 +25,6 @@ serde_json = "1.0.61"
 sled = "0.34.6"
 thiserror = "1.0.30"
 tide = "0.16.0"
-tracing = { version = "0.1.26", default-features = false, features= ["log", "log-always", "attributes", "std"] }
+tracing = { version = "0.1.26", default-features = false, features= ["log", "attributes", "std"] }
 tracing-subscriber = { version = "0.3.1", features = [ "env-filter" ] }
 tokio = {version = "1.0", features = ["full"]}


### PR DESCRIPTION
This fixes #263

To test this, add a logging statement like `tracing::info!("hello")` in the `main` function of `ln_gateway.rs`.

Run the gateway inside lightningd e.g. with `setup-test.sh`. You'll see your log output is there.

Now run `cargo test peg_in_and_peg_out_with_fees` and you'll see that output isn't repeated. On master it is e.g. https://discord.com/channels/990354215060795454/992503915578933268/996530029582360667.

Also, this makes sense from the [docs](https://docs.rs/tracing/latest/tracing/#crate-feature-flags). The `log-always` feature always logs -- so if we have a tracing subscriber that's also logging we'll get duplicates. But `log` just logs if there **isn't** a tracing subscriber. So that's not a problem because we should always have a tracing subscriber except in core-lightning plugin context.