### PR TITLE
nit: fix debug error spelling

### DIFF
--- a/minimint/src/consensus/debug.rs
+++ b/minimint/src/consensus/debug.rs
@@ -41,7 +41,7 @@ fn item_message(item: &ConsensusItem) -> String {
             )
         }
         ConsensusItem::LN(DecryptionShareCI { contract_id, .. }) => {
-            format!("LN Decrytion Share for contract {}", contract_id)
+            format!("LN Decryption Share for contract {}", contract_id)
         }
         ConsensusItem::Transaction(Transaction {
             inputs, outputs, ..


### PR DESCRIPTION
tiny spelling nit, noticed during @base58btc's summer base58 n' coding demo