### PR TITLE
add user determined fees to peg-outs

### DIFF
--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -5,6 +5,7 @@ use minimint_api::Amount;
 use minimint_core::config::load_from_file;
 use minimint_core::modules::mint::tiered::coins::Coins;
 use minimint_core::modules::wallet::txoproof::TxOutProof;
+
 use mint_client::mint::SpendableCoin;
 use mint_client::utils::{
     from_hex, parse_bitcoin_amount, parse_coins, parse_minimint_amount, serialize_coins,
@@ -152,7 +153,8 @@ async fn main() {
             }
         }
         Command::PegOut { address, satoshis } => {
-            client.peg_out(satoshis, address, &mut rng).await.unwrap();
+            let peg_out = client.fetch_peg_out_fees(satoshis, address).await.unwrap();
+            client.peg_out(peg_out, &mut rng).await.unwrap();
         }
         Command::LnPay { bolt11 } => {
             let http = reqwest::Client::new();

--- a/client/cli/src/main.rs
+++ b/client/cli/src/main.rs
@@ -153,7 +153,10 @@ async fn main() {
             }
         }
         Command::PegOut { address, satoshis } => {
-            let peg_out = client.fetch_peg_out_fees(satoshis, address).await.unwrap();
+            let peg_out = client
+                .new_peg_out_with_fees(satoshis, address)
+                .await
+                .unwrap();
             client.peg_out(peg_out, &mut rng).await.unwrap();
         }
         Command::LnPay { bolt11 } => {

--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -46,8 +46,8 @@ pub trait FederationApi: Send + Sync {
     /// Fetch the expected peg-out fees given a peg-out tx
     async fn fetch_peg_out_fees(
         &self,
-        address: Address,
-        amount: Amount,
+        address: &Address,
+        amount: &Amount,
     ) -> Result<Option<PegOutFees>>;
 }
 
@@ -58,7 +58,6 @@ impl<'a> dyn FederationApi + 'a {
     {
         match self.fetch_tx_outcome(out_point.txid).await? {
             TransactionStatus::Rejected(e) => Err(ApiError::TransactionRejected(e)),
-            TransactionStatus::Error(e) => Err(ApiError::TransactionError(e)),
             TransactionStatus::Accepted { outputs, .. } => {
                 let outputs_len = outputs.len();
                 outputs
@@ -203,8 +202,8 @@ impl<C: JsonRpcClient + Send + Sync> FederationApi for WsFederationApi<C> {
 
     async fn fetch_peg_out_fees(
         &self,
-        address: Address,
-        amount: Amount,
+        address: &Address,
+        amount: &Amount,
     ) -> Result<Option<PegOutFees>> {
         self.request("/wallet/peg_out_fees", (address, amount.as_sat()))
             .await

--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -7,9 +7,14 @@ pub mod wallet;
 
 use std::{sync::Arc, time::Duration};
 
+use futures::StreamExt;
+
 use bitcoin::util::key::KeyPair;
 use bitcoin::{Address, Transaction as BitcoinTransaction};
+
 use bitcoin_hashes::Hash;
+use futures::stream::FuturesUnordered;
+
 use lightning::ln::PaymentSecret;
 use lightning::routing::gossip::RoutingFees;
 use lightning::routing::router::{RouteHint, RouteHintHop};
@@ -27,6 +32,7 @@ use minimint_core::modules::ln::contracts::incoming::{
 use minimint_core::modules::ln::contracts::{outgoing, Contract, IdentifyableContract};
 use minimint_core::modules::ln::ContractOutput;
 use minimint_core::modules::wallet::PegOut;
+use minimint_core::outcome::TransactionStatus;
 use minimint_core::transaction::TransactionItem;
 use minimint_core::{
     config::ClientConfig,
@@ -51,6 +57,7 @@ use crate::ln::db::{
 };
 use crate::ln::outgoing::OutgoingContractAccount;
 use crate::ln::LnClientError;
+use crate::mint::db::{CoinKey, PendingCoinsKeyPrefix};
 use crate::mint::MintClientError;
 use crate::transaction::TransactionBuilder;
 use crate::utils::{network_to_currency, OwnedClientContext};
@@ -192,23 +199,13 @@ impl<T: AsRef<ClientConfig>> Client<T> {
     async fn submit_tx_with_change<R: RngCore + CryptoRng>(
         &self,
         tx: TransactionBuilder,
-        mut batch: Accumulator<BatchItem>,
-        mut rng: R,
+        batch: Accumulator<BatchItem>,
+        rng: R,
     ) -> Result<TransactionId> {
-        let change = tx.change_required(&self.context.config.as_ref().fee_consensus);
-        let final_tx =
-            self.mint_client()
-                .finalize_change(change, batch.transaction(), tx, &mut rng);
-        let txid = final_tx.tx_hash();
-        let mint_tx_id = self.context.api.submit_transaction(final_tx).await?;
-        // TODO: make check part of submit_transaction
-        assert_eq!(
-            txid, mint_tx_id,
-            "Federation is faulty, returned wrong tx id."
-        );
-
-        self.context.db.apply_batch(batch).expect("DB error");
-        Ok(txid)
+        Ok(self
+            .mint_client()
+            .submit_tx_with_change(&self.context.config.as_ref().fee_consensus, tx, batch, rng)
+            .await?)
     }
 
     /// Exchanges `coins` received from an untrusted third party for newly issued ones to prevent
@@ -224,9 +221,7 @@ impl<T: AsRef<ClientConfig>> Client<T> {
         mut rng: R,
     ) -> Result<OutPoint> {
         let mut tx = TransactionBuilder::default();
-
-        let (mut coin_keys, coin_input) = self.mint_client().create_coin_input_from_coins(coins)?;
-        tx.input(&mut coin_keys, Input::Mint(coin_input));
+        tx.input_coins(coins, &self.context.secp)?;
         let txid = self
             .submit_tx_with_change(tx, DbBatch::new(), &mut rng)
             .await?;
@@ -239,14 +234,11 @@ impl<T: AsRef<ClientConfig>> Client<T> {
         coins: Coins<BlindToken>,
         mut rng: R,
     ) -> Result<OutPoint> {
-        let mut batch = DbBatch::new();
+        let batch = DbBatch::new();
         let mut tx = TransactionBuilder::default();
 
-        let (mut coin_keys, coin_input) = self
-            .mint_client()
-            .create_coin_input(batch.transaction(), coins.amount())?;
-
-        tx.input(&mut coin_keys, Input::Mint(coin_input));
+        let input_coins = self.mint_client().select_coins(coins.amount())?;
+        tx.input_coins(input_coins, &self.context.secp)?;
         tx.output(Output::Mint(coins));
         let txid = self.submit_tx_with_change(tx, batch, &mut rng).await?;
 
@@ -260,14 +252,12 @@ impl<T: AsRef<ClientConfig>> Client<T> {
         create_tx: impl FnMut(Coins<BlindToken>) -> OutPoint,
     ) {
         let mut batch = DbBatch::new();
-
         self.mint_client()
-            .create_coin_output(batch.transaction(), amount, rng, create_tx);
-
+            .receive_coins(amount, batch.transaction(), rng, create_tx);
         self.context.db.apply_batch(batch).expect("DB error");
     }
 
-    pub async fn fetch_peg_out_fees(
+    pub async fn new_peg_out_with_fees(
         &self,
         amount: bitcoin::Amount,
         recipient: Address,
@@ -275,7 +265,7 @@ impl<T: AsRef<ClientConfig>> Client<T> {
         let fees = self
             .context
             .api
-            .fetch_peg_out_fees(recipient.clone(), amount)
+            .fetch_peg_out_fees(&recipient, &amount)
             .await?;
         fees.map(|fees| PegOut {
             recipient,
@@ -290,16 +280,13 @@ impl<T: AsRef<ClientConfig>> Client<T> {
         peg_out: PegOut,
         mut rng: R,
     ) -> Result<TransactionId> {
-        let mut batch = DbBatch::new();
+        let batch = DbBatch::new();
         let mut tx = TransactionBuilder::default();
 
         let funding_amount = self.context.config.as_ref().fee_consensus.fee_peg_out_abs
             + (peg_out.amount + peg_out.fees.amount()).into();
-        let (mut coin_keys, coin_input) = self
-            .mint_client()
-            .create_coin_input(batch.transaction(), funding_amount)?;
-
-        tx.input(&mut coin_keys, Input::Mint(coin_input));
+        let coins = self.mint_client().select_coins(funding_amount)?;
+        tx.input_coins(coins, &self.context.secp)?;
         tx.output(Output::Wallet(peg_out));
 
         self.submit_tx_with_change(tx, batch, &mut rng).await
@@ -314,11 +301,19 @@ impl<T: AsRef<ClientConfig>> Client<T> {
         address
     }
 
+    /// **WARNING** this selects and removes coins from the database without confirming whether
+    /// we have successfully spent them in a transaction.
     pub fn select_and_spend_coins(&self, amount: Amount) -> Result<Coins<SpendableCoin>> {
         let mut batch = DbBatch::new();
-        let coins = self
-            .mint_client()
-            .select_and_spend_coins(batch.transaction(), amount)?;
+        let mut tx = batch.transaction();
+        let coins = self.mint_client().select_coins(amount)?;
+        tx.append_from_iter(coins.iter().map(|(amount, coin)| {
+            BatchItem::delete(CoinKey {
+                amount,
+                nonce: coin.coin.0.clone(),
+            })
+        }));
+        tx.commit();
         self.context.db.apply_batch(batch).expect("DB error");
         Ok(coins)
     }
@@ -333,6 +328,42 @@ impl<T: AsRef<ClientConfig>> Client<T> {
             .await?;
         self.context.db.apply_batch(batch).expect("DB error");
         Ok(())
+    }
+
+    /// Should be called after any transaction that might have failed in order to get any coin
+    /// inputs back.
+    pub async fn reissue_pending_coins<R: RngCore + CryptoRng>(&self, rng: R) -> Result<OutPoint> {
+        let pending = self
+            .context
+            .db
+            .find_by_prefix(&PendingCoinsKeyPrefix)
+            .map(|res| res.expect("DB error"));
+
+        let stream = pending
+            .map(|(key, coins)| async move {
+                loop {
+                    match self.context.api.fetch_tx_outcome(key.0).await {
+                        Ok(TransactionStatus::Rejected(_)) => return (key, coins),
+                        Ok(TransactionStatus::Accepted { .. }) => {
+                            return (key, Coins::<SpendableCoin>::default())
+                        }
+                        _ => {}
+                    }
+                }
+            })
+            .collect::<FuturesUnordered<_>>();
+
+        let mut batch = DbBatch::new();
+        let mut tx = batch.transaction();
+        let mut all_coins = Coins::<SpendableCoin>::default();
+        for (key, coins) in stream.collect::<Vec<_>>().await {
+            all_coins.extend(coins);
+            tx.append_delete(key);
+        }
+        tx.commit();
+        self.context.db.apply_batch(batch).unwrap();
+
+        self.reissue(all_coins, rng).await
     }
 
     pub async fn fetch_all_coins<'a>(&self) -> Vec<Result<OutPoint>> {
@@ -380,12 +411,8 @@ impl Client<UserClientConfig> {
         };
         let ln_output = Output::LN(contract);
 
-        let amount = ln_output.amount();
-        let (mut coin_keys, coin_input) = self
-            .mint_client()
-            .create_coin_input(batch.transaction(), amount)?;
-
-        tx.input(&mut coin_keys, Input::Mint(coin_input));
+        let coins = self.mint_client().select_coins(ln_output.amount())?;
+        tx.input_coins(coins, &self.context.secp)?;
         tx.output(ln_output);
         let txid = self.submit_tx_with_change(tx, batch, &mut rng).await?;
         let outpoint = OutPoint { txid, out_idx: 0 };
@@ -600,7 +627,7 @@ impl Client<GatewayClientConfig> {
         &self,
         contract_id: ContractId,
         preimage: [u8; 32],
-        mut rng: impl RngCore + CryptoRng,
+        rng: impl RngCore + CryptoRng,
     ) -> Result<OutPoint> {
         let mut batch = DbBatch::new();
         let mut tx = TransactionBuilder::default();
@@ -608,20 +635,13 @@ impl Client<GatewayClientConfig> {
         let contract = self.ln_client().get_outgoing_contract(contract_id).await?;
         let input = Input::LN(contract.claim(outgoing::Preimage(preimage)));
 
-        tx.input(&mut vec![self.context.config.redeem_key], input);
-        let change = tx.change_required(&self.context.config.client_config.fee_consensus);
-        let final_tx =
-            self.mint_client()
-                .finalize_change(change, batch.transaction(), tx, &mut rng);
-        let txid = final_tx.tx_hash();
-
         batch.autocommit(|batch| {
             batch.append_delete(OutgoingContractAccountKey(contract_id));
-            batch.append_insert(OutgoingPaymentClaimKey(contract_id), final_tx.clone());
+            batch.append_insert(OutgoingPaymentClaimKey(contract_id), ());
         });
 
-        self.context.db.apply_batch(batch).expect("DB error");
-        self.context.api.submit_transaction(final_tx).await?;
+        tx.input(&mut vec![self.context.config.redeem_key], input);
+        let txid = self.submit_tx_with_change(tx, batch, rng).await?;
 
         Ok(OutPoint { txid, out_idx: 0 })
     }
@@ -630,9 +650,9 @@ impl Client<GatewayClientConfig> {
         &self,
         payment_hash: &bitcoin_hashes::sha256::Hash,
         amount: &Amount,
-        mut rng: impl RngCore + CryptoRng,
+        rng: impl RngCore + CryptoRng,
     ) -> Result<(OutPoint, ContractId)> {
-        let mut batch = DbBatch::new();
+        let batch = DbBatch::new();
 
         // Fetch offer for this payment hash
         let offer: IncomingContractOffer = self.ln_client().get_offer(*payment_hash).await?;
@@ -641,9 +661,9 @@ impl Client<GatewayClientConfig> {
         }
 
         // Inputs
-        let (mut coin_keys, coin_input) = self
-            .mint_client()
-            .create_coin_input(batch.transaction(), offer.amount)?;
+        let mut builder = TransactionBuilder::default();
+        let coins = self.mint_client().select_coins(offer.amount)?;
+        builder.input_coins(coins, &self.context.secp)?;
 
         // Outputs
         let our_pub_key =
@@ -662,20 +682,11 @@ impl Client<GatewayClientConfig> {
         );
 
         // Submit transaction
-        let mut builder = TransactionBuilder::default();
-        builder.input(&mut coin_keys, Input::Mint(coin_input));
         builder.output(incoming_output);
-        let change = builder.change_required(&self.context.config.client_config.fee_consensus);
-        let tx = self
-            .mint_client()
-            .finalize_change(change, batch.transaction(), builder, &mut rng);
-        let txid = self.context.api.submit_transaction(tx).await?;
+        let txid = self.submit_tx_with_change(builder, batch, rng).await?;
         let outpoint = OutPoint { txid, out_idx: 0 };
 
         // FIXME: Save this contract in DB
-
-        self.context.db.apply_batch(batch).expect("DB error");
-
         Ok((outpoint, contract.contract_id()))
     }
 
@@ -683,9 +694,9 @@ impl Client<GatewayClientConfig> {
     pub async fn refund_incoming_contract(
         &self,
         contract_id: ContractId,
-        mut rng: impl RngCore + CryptoRng,
+        rng: impl RngCore + CryptoRng,
     ) -> Result<TransactionId> {
-        let mut batch = DbBatch::new();
+        let batch = DbBatch::new();
         let contract_account = self.ln_client().get_incoming_contract(contract_id).await?;
 
         let mut builder = TransactionBuilder::default();
@@ -695,12 +706,7 @@ impl Client<GatewayClientConfig> {
             &mut vec![self.context.config.redeem_key],
             Input::LN(contract_account.claim()),
         );
-        let change = builder.change_required(&self.context.config.client_config.fee_consensus);
-        let tx = self
-            .mint_client()
-            .finalize_change(change, batch.transaction(), builder, &mut rng);
-        let mint_tx_id = self.context.api.submit_transaction(tx).await?;
-        self.context.db.apply_batch(batch).expect("DB error");
+        let mint_tx_id = self.submit_tx_with_change(builder, batch, rng).await?;
         Ok(mint_tx_id)
     }
 

--- a/client/client-lib/src/ln/db.rs
+++ b/client/client-lib/src/ln/db.rs
@@ -2,7 +2,6 @@ use crate::ln::outgoing::OutgoingContractData;
 use minimint_api::db::DatabaseKeyPrefixConst;
 use minimint_api::encoding::{Decodable, Encodable};
 use minimint_core::modules::ln::contracts::ContractId;
-use minimint_core::transaction::Transaction;
 
 use super::incoming::ConfirmedInvoice;
 use super::outgoing::OutgoingContractAccount;
@@ -36,7 +35,7 @@ pub struct OutgoingPaymentClaimKey(pub ContractId);
 impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKey {
     const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_PAYMENT_CLAIM;
     type Key = Self;
-    type Value = Transaction;
+    type Value = ();
 }
 
 #[derive(Debug, Encodable, Decodable)]
@@ -45,7 +44,7 @@ pub struct OutgoingPaymentClaimKeyPrefix;
 impl DatabaseKeyPrefixConst for OutgoingPaymentClaimKeyPrefix {
     const DB_PREFIX: u8 = DB_PREFIX_OUTGOING_PAYMENT_CLAIM;
     type Key = OutgoingPaymentClaimKey;
-    type Value = Transaction;
+    type Value = ();
 }
 
 #[derive(Debug, Encodable, Decodable)]

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -271,8 +271,8 @@ mod tests {
 
         async fn fetch_peg_out_fees(
             &self,
-            _address: Address,
-            _amount: bitcoin::Amount,
+            _address: &Address,
+            _amount: &bitcoin::Amount,
         ) -> crate::api::Result<Option<PegOutFees>> {
             unimplemented!();
         }

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -201,6 +201,7 @@ mod tests {
     use crate::ln::LnClient;
     use crate::OwnedClientContext;
     use async_trait::async_trait;
+    use bitcoin::Address;
     use lightning_invoice::Invoice;
     use minimint_api::db::batch::DbBatch;
     use minimint_api::db::mem_impl::MemDatabase;
@@ -211,6 +212,7 @@ mod tests {
     use minimint_core::modules::ln::contracts::{ContractId, IdentifyableContract};
     use minimint_core::modules::ln::ContractOrOfferOutput;
     use minimint_core::modules::ln::{ContractAccount, LightningModule};
+    use minimint_core::modules::wallet::PegOutFees;
     use minimint_core::outcome::{OutputOutcome, TransactionStatus};
     use minimint_core::transaction::Transaction;
     use std::sync::Arc;
@@ -264,6 +266,14 @@ mod tests {
             &self,
             _payment_hash: bitcoin::hashes::sha256::Hash,
         ) -> crate::api::Result<IncomingContractOffer> {
+            unimplemented!();
+        }
+
+        async fn fetch_peg_out_fees(
+            &self,
+            _address: Address,
+            _amount: bitcoin::Amount,
+        ) -> crate::api::Result<Option<PegOutFees>> {
             unimplemented!();
         }
     }

--- a/client/client-lib/src/mint/db.rs
+++ b/client/client-lib/src/mint/db.rs
@@ -1,11 +1,13 @@
 use crate::mint::{CoinFinalizationData, SpendableCoin};
 use minimint_api::db::DatabaseKeyPrefixConst;
 use minimint_api::encoding::{Decodable, Encodable};
-use minimint_api::{Amount, OutPoint};
+use minimint_api::{Amount, OutPoint, TransactionId};
+use minimint_core::modules::mint::tiered::coins::Coins;
 use minimint_core::modules::mint::CoinNonce;
 
 pub const DB_PREFIX_COIN: u8 = 0x20;
 pub const DB_PREFIX_OUTPUT_FINALIZATION_DATA: u8 = 0x21;
+pub const DB_PREFIX_PENDING_COINS: u8 = 0x27;
 
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub struct CoinKey {
@@ -26,6 +28,24 @@ impl DatabaseKeyPrefixConst for CoinKeyPrefix {
     const DB_PREFIX: u8 = DB_PREFIX_COIN;
     type Key = CoinKey;
     type Value = SpendableCoin;
+}
+
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub struct PendingCoinsKey(pub TransactionId);
+
+impl DatabaseKeyPrefixConst for PendingCoinsKey {
+    const DB_PREFIX: u8 = DB_PREFIX_PENDING_COINS;
+    type Key = Self;
+    type Value = Coins<SpendableCoin>;
+}
+
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub struct PendingCoinsKeyPrefix;
+
+impl DatabaseKeyPrefixConst for PendingCoinsKeyPrefix {
+    const DB_PREFIX: u8 = DB_PREFIX_PENDING_COINS;
+    type Key = PendingCoinsKey;
+    type Value = Coins<SpendableCoin>;
 }
 
 #[derive(Debug, Clone, Encodable, Decodable)]

--- a/client/client-lib/src/mint/mod.rs
+++ b/client/client-lib/src/mint/mod.rs
@@ -1,22 +1,23 @@
-mod db;
+pub mod db;
 
 use crate::api::ApiError;
 use crate::transaction::TransactionBuilder;
 use crate::utils::BorrowedClientContext;
-use bitcoin::KeyPair;
+
 use db::{CoinKey, CoinKeyPrefix, OutputFinalizationKey, OutputFinalizationKeyPrefix};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use minimint_api::db::batch::{BatchItem, BatchTx, DbBatch};
+use minimint_api::db::batch::{Accumulator, BatchItem, BatchTx, DbBatch};
 use minimint_api::encoding::{Decodable, Encodable};
 use minimint_api::{Amount, OutPoint, TransactionId};
+use minimint_core::config::FeeConsensus;
 use minimint_core::modules::mint::config::MintClientConfig;
 use minimint_core::modules::mint::tiered::coins::Coins;
 use minimint_core::modules::mint::{
     BlindToken, Coin, CoinNonce, InvalidAmountTierError, Keys, SigResponse, SignRequest,
 };
-use minimint_core::transaction::{Output, Transaction};
-use rand::{CryptoRng, Rng, RngCore};
+
+use rand::{CryptoRng, RngCore};
 use secp256k1_zkp::{Secp256k1, Signing};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -70,119 +71,59 @@ impl<'c> MintClient<'c> {
             .collect()
     }
 
-    pub fn mark_coins_spent(&self, mut batch: BatchTx, coins: &Coins<SpendableCoin>) {
-        batch.append_from_iter(coins.iter().map(|(amount, coin)| {
-            BatchItem::delete(CoinKey {
-                amount,
-                nonce: coin.coin.0.clone(),
-            })
-        }));
-        batch.commit();
-    }
-
-    pub fn select_and_spend_coins(
-        &self,
-        mut batch: BatchTx,
-        amount: Amount,
-    ) -> Result<Coins<SpendableCoin>> {
+    pub fn select_coins(&self, amount: Amount) -> Result<Coins<SpendableCoin>> {
         let coins = self
             .coins()
             .select_coins(amount)
             .ok_or(MintClientError::NotEnoughCoins)?;
 
-        // mark spent in DB
-        // TODO: make contingent on success of payment
-        self.mark_coins_spent(batch.subtransaction(), &coins);
-        batch.commit();
         Ok(coins)
     }
 
-    /// Select coins to fund a transaction with.
-    ///
-    /// **ATTENTION**: calling this function multiple times without committing the batch to the
-    /// database is not supported and will result in an accidental double spend.
-    pub fn create_coin_input(
+    pub async fn submit_tx_with_change<R: RngCore + CryptoRng>(
         &self,
-        mut batch: BatchTx,
-        amount: Amount,
-    ) -> Result<(Vec<KeyPair>, Coins<Coin>)> {
-        let coins = self.select_and_spend_coins(batch.subtransaction(), amount)?;
-        let (spend_keys, coins) = self.create_coin_input_from_coins(coins)?;
-        batch.commit();
-        Ok((spend_keys, coins))
-    }
-
-    pub fn create_coin_input_from_coins(
-        &self,
-        coins: Coins<SpendableCoin>,
-    ) -> Result<(Vec<KeyPair>, Coins<Coin>)> {
-        let coin_key_pairs = coins
-            .into_iter()
-            .map(|(amt, coin)| {
-                let spend_key =
-                    bitcoin::KeyPair::from_seckey_slice(self.context.secp, &coin.spend_key)
-                        .map_err(|_| MintClientError::ReceivedUspendableCoin)?;
-
-                // We check for coin validity in case we got it from an untrusted third party. We
-                // don't want to needlessly create invalid tx and bother the federation with them.
-                let spend_pub_key = spend_key.public_key();
-                if &spend_pub_key == coin.coin.spend_key() {
-                    Ok((spend_key, (amt, coin.coin)))
-                } else {
-                    Err(MintClientError::ReceivedUspendableCoin)
-                }
-            })
-            .collect::<Result<Vec<_>>>()?;
-        Ok(coin_key_pairs.into_iter().unzip())
-    }
-
-    /// Adds change to a TransactionBuilder as the last output (if necessary) and builds the final Transaction
-    pub fn finalize_change<R: Rng + CryptoRng>(
-        &self,
-        change_required: Amount,
-        batch: BatchTx,
-        mut tx: TransactionBuilder,
-        mut rng: R,
-    ) -> Transaction {
-        let min_change = *self.context.config.tbs_pks.tiers().min().unwrap();
-
-        if change_required >= min_change {
-            self.create_coin_output(batch, change_required, &mut rng, |change_output| {
-                tx.output(Output::Mint(change_output));
-                OutPoint {
-                    txid: tx.tx.tx_hash(),
-                    out_idx: (tx.tx.outputs.len() - 1) as u64,
-                }
-            });
-        }
-
-        tx.build(self.context.secp, &mut rng)
-    }
-
-    pub fn create_coin_output<R: Rng + CryptoRng>(
-        &self,
-        mut batch: BatchTx,
-        amount: Amount,
-        mut rng: R,
-        mut tx: impl FnMut(Coins<BlindToken>) -> OutPoint,
-    ) {
-        let (coin_finalization_data, sig_req) = CoinFinalizationData::new(
-            amount,
-            &self.context.config.tbs_pks,
+        fee_consensus: &FeeConsensus,
+        tx: TransactionBuilder,
+        mut batch: Accumulator<BatchItem>,
+        rng: R,
+    ) -> Result<TransactionId> {
+        let change_required = tx.change_required(fee_consensus);
+        let final_tx = tx.build(
+            change_required,
+            batch.transaction(),
             self.context.secp,
-            &mut rng,
+            &self.context.config.tbs_pks,
+            rng,
+        );
+        let txid = final_tx.tx_hash();
+        let mint_tx_id = self.context.api.submit_transaction(final_tx).await?;
+        assert_eq!(
+            txid, mint_tx_id,
+            "Federation is faulty, returned wrong tx id."
         );
 
-        let coin_output = sig_req
-            .0
-            .into_iter()
-            .map(|(amt, token)| (amt, BlindToken(token)))
-            .collect();
+        self.context.db.apply_batch(batch).expect("DB error");
+        Ok(txid)
+    }
 
-        let out_point = tx(coin_output);
+    pub fn receive_coins<R: RngCore + CryptoRng>(
+        &self,
+        amount: Amount,
+        mut tx: BatchTx,
+        rng: R,
+        mut create_tx: impl FnMut(Coins<BlindToken>) -> OutPoint,
+    ) {
+        let mut builder = TransactionBuilder::default();
 
-        batch.append_insert_new(OutputFinalizationKey(out_point), coin_finalization_data);
-        batch.commit();
+        let (finalization, coins) = builder.create_output_coins(
+            amount,
+            self.context.secp,
+            &self.context.config.tbs_pks,
+            rng,
+        );
+        let out_point = create_tx(coins);
+        tx.append_insert_new(OutputFinalizationKey(out_point), finalization);
+        tx.commit();
     }
 
     pub async fn fetch_coins(&self, mut batch: BatchTx<'_>, outpoint: OutPoint) -> Result<()> {
@@ -417,7 +358,7 @@ mod tests {
     use crate::api::FederationApi;
 
     use crate::mint::MintClient;
-    use crate::OwnedClientContext;
+    use crate::{OwnedClientContext, TransactionBuilder};
     use async_trait::async_trait;
     use bitcoin::hashes::Hash;
     use bitcoin::Address;
@@ -486,8 +427,8 @@ mod tests {
 
         async fn fetch_peg_out_fees(
             &self,
-            _address: Address,
-            _amount: bitcoin::Amount,
+            _address: &Address,
+            _amount: &bitcoin::Amount,
         ) -> crate::api::Result<Option<PegOutFees>> {
             unimplemented!();
         }
@@ -529,7 +470,7 @@ mod tests {
         let out_point = OutPoint { txid, out_idx: 0 };
 
         let mut batch = DbBatch::new();
-        client.create_coin_output(batch.transaction(), amt, rng, |output| {
+        client.receive_coins(amt, batch.transaction(), rng, |output| {
             // Agree on output
             let mut fed = block_on(fed.lock());
             block_on(fed.consensus_round(&[], &[(out_point, output)]));
@@ -587,10 +528,16 @@ mod tests {
 
         // Spending works
         let mut batch = DbBatch::new();
-        let coins = client
-            .select_and_spend_coins(batch.transaction(), SPEND_AMOUNT)
+        let mut builder = TransactionBuilder::default();
+        let secp = client.context.secp;
+        let tbs_pks = &client.context.config.tbs_pks;
+        let rng = rand::rngs::OsRng::new().unwrap();
+        let coins = client.select_coins(SPEND_AMOUNT).unwrap();
+        let (spend_keys, input) = builder
+            .create_input_from_coins(coins.clone(), secp)
             .unwrap();
-        let (spend_keys, input) = client.create_coin_input_from_coins(coins).unwrap();
+        builder.input_coins(coins, secp).unwrap();
+        builder.build(Amount::from_sat(0), batch.transaction(), secp, tbs_pks, rng);
         client_context.db.apply_batch(batch).unwrap();
 
         let meta = fed.lock().await.verify_input(&input).unwrap();
@@ -616,10 +563,14 @@ mod tests {
 
         // We can exactly spend the remainder
         let mut batch = DbBatch::new();
-        let coins = client
-            .select_and_spend_coins(batch.transaction(), SPEND_AMOUNT)
+        let mut builder = TransactionBuilder::default();
+        let coins = client.select_coins(SPEND_AMOUNT).unwrap();
+        let rng = rand::rngs::OsRng::new().unwrap();
+        let (spend_keys, input) = builder
+            .create_input_from_coins(coins.clone(), secp)
             .unwrap();
-        let (spend_keys, input) = client.create_coin_input_from_coins(coins).unwrap();
+        builder.input_coins(coins, secp).unwrap();
+        builder.build(Amount::from_sat(0), batch.transaction(), secp, tbs_pks, rng);
         client_context.db.apply_batch(batch).unwrap();
 
         let meta = fed.lock().await.verify_input(&input).unwrap();

--- a/client/client-lib/src/transaction.rs
+++ b/client/client-lib/src/transaction.rs
@@ -1,18 +1,29 @@
 use rand::{CryptoRng, RngCore};
 
+use crate::mint::db::{CoinKey, OutputFinalizationKey, PendingCoinsKey};
+use crate::mint::CoinFinalizationData;
+use crate::{MintClientError, SpendableCoin};
 use bitcoin::KeyPair;
-use minimint_api::Amount;
+use minimint_api::db::batch::{BatchItem, BatchTx};
+use minimint_api::{Amount, OutPoint};
 use minimint_core::config::FeeConsensus;
+use minimint_core::modules::mint::tiered::coins::Coins;
+use minimint_core::modules::mint::{BlindToken, Coin, Keys};
 use minimint_core::transaction::{Input, Output, Transaction};
+use tbs::AggregatePublicKey;
 
 pub struct TransactionBuilder {
+    input_coins: Coins<SpendableCoin>,
+    output_coins: Vec<(u64, CoinFinalizationData)>,
     keys: Vec<KeyPair>,
-    pub tx: Transaction,
+    tx: Transaction,
 }
 
 impl Default for TransactionBuilder {
     fn default() -> Self {
         TransactionBuilder {
+            input_coins: Default::default(),
+            output_coins: vec![],
             keys: vec![],
             tx: Transaction {
                 inputs: vec![],
@@ -24,6 +35,41 @@ impl Default for TransactionBuilder {
 }
 
 impl TransactionBuilder {
+    pub fn input_coins(
+        &mut self,
+        coins: Coins<SpendableCoin>,
+        secp: &secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
+    ) -> Result<(), MintClientError> {
+        self.input_coins.extend(coins.clone());
+        let (mut coin_keys, coin_input) = self.create_input_from_coins(coins, secp)?;
+        self.input(&mut coin_keys, Input::Mint(coin_input));
+        Ok(())
+    }
+
+    pub fn create_input_from_coins(
+        &mut self,
+        coins: Coins<SpendableCoin>,
+        secp: &secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
+    ) -> Result<(Vec<KeyPair>, Coins<Coin>), MintClientError> {
+        let coin_key_pairs = coins
+            .into_iter()
+            .map(|(amt, coin)| {
+                let spend_key = bitcoin::KeyPair::from_seckey_slice(secp, &coin.spend_key)
+                    .map_err(|_| MintClientError::ReceivedUspendableCoin)?;
+
+                // We check for coin validity in case we got it from an untrusted third party. We
+                // don't want to needlessly create invalid tx and bother the federation with them.
+                let spend_pub_key = spend_key.public_key();
+                if &spend_pub_key == coin.coin.spend_key() {
+                    Ok((spend_key, (amt, coin.coin)))
+                } else {
+                    Err(MintClientError::ReceivedUspendableCoin)
+                }
+            })
+            .collect::<Result<Vec<_>, MintClientError>>()?;
+        Ok(coin_key_pairs.into_iter().unzip())
+    }
+
     pub fn input(&mut self, key: &mut Vec<KeyPair>, input: Input) {
         self.keys.append(key);
         self.tx.inputs.push(input);
@@ -37,21 +83,84 @@ impl TransactionBuilder {
         self.tx.in_amount() - self.tx.out_amount() - self.tx.fee_amount(fees)
     }
 
+    pub fn output_coins<R: RngCore + CryptoRng>(
+        &mut self,
+        amount: Amount,
+        secp: &secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
+        tbs_pks: &Keys<AggregatePublicKey>,
+        rng: R,
+    ) {
+        let (coin_finalization_data, coin_output) =
+            self.create_output_coins(amount, secp, tbs_pks, rng);
+
+        if !coin_output.coins.is_empty() {
+            let out_idx = self.tx.outputs.len();
+            self.output(Output::Mint(coin_output));
+            self.output_coins
+                .push((out_idx as u64, coin_finalization_data));
+        }
+    }
+
+    pub fn create_output_coins<R: RngCore + CryptoRng>(
+        &mut self,
+        amount: Amount,
+        secp: &secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
+        tbs_pks: &Keys<AggregatePublicKey>,
+        rng: R,
+    ) -> (CoinFinalizationData, Coins<BlindToken>) {
+        let (coin_finalization_data, sig_req) =
+            CoinFinalizationData::new(amount, tbs_pks, secp, rng);
+
+        let coin_output = sig_req
+            .0
+            .into_iter()
+            .map(|(amt, token)| (amt, BlindToken(token)))
+            .collect();
+
+        (coin_finalization_data, coin_output)
+    }
+
     pub fn build<R: RngCore + CryptoRng>(
         mut self,
+        change_required: Amount,
+        mut batch: BatchTx,
         secp: &secp256k1_zkp::Secp256k1<secp256k1_zkp::All>,
+        tbs_pks: &Keys<AggregatePublicKey>,
         mut rng: R,
     ) -> Transaction {
+        // add change
+        self.output_coins(change_required, secp, tbs_pks, &mut rng);
+
+        let txid = self.tx.tx_hash();
         if !self.keys.is_empty() {
-            let signature = minimint_core::transaction::agg_sign(
-                &self.keys,
-                self.tx.tx_hash().as_hash(),
-                secp,
-                &mut rng,
-            );
+            let signature =
+                minimint_core::transaction::agg_sign(&self.keys, txid.as_hash(), secp, &mut rng);
             self.tx.signature = Some(signature);
         }
 
+        // move input coins to pending state, awaiting a transaction
+        if !self.input_coins.coins.is_empty() {
+            batch.append_from_iter(self.input_coins.iter().map(|(amount, coin)| {
+                BatchItem::delete(CoinKey {
+                    amount,
+                    nonce: coin.coin.0.clone(),
+                })
+            }));
+            batch.append_insert(PendingCoinsKey(txid), self.input_coins);
+        }
+
+        // write coin output to db to await for tx success to be fetched later
+        self.output_coins.iter().for_each(|(out_idx, coins)| {
+            batch.append_insert_new(
+                OutputFinalizationKey(OutPoint {
+                    txid,
+                    out_idx: *out_idx,
+                }),
+                coins.clone(),
+            );
+        });
+
+        batch.commit();
         self.tx
     }
 }

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -188,8 +188,8 @@ mod tests {
 
         async fn fetch_peg_out_fees(
             &self,
-            _address: Address,
-            _amount: bitcoin::Amount,
+            _address: &Address,
+            _amount: &bitcoin::Amount,
         ) -> crate::api::Result<Option<PegOutFees>> {
             unimplemented!();
         }

--- a/client/client-lib/src/wallet/mod.rs
+++ b/client/client-lib/src/wallet/mod.rs
@@ -8,7 +8,7 @@ use minimint_core::config::FeeConsensus;
 use minimint_core::modules::wallet::config::WalletClientConfig;
 use minimint_core::modules::wallet::tweakable::Tweakable;
 use minimint_core::modules::wallet::txoproof::{PegInProof, PegInProofError, TxOutProof};
-use minimint_core::modules::wallet::PegOut;
+
 use miniscript::descriptor::DescriptorTrait;
 use rand::{CryptoRng, RngCore};
 use thiserror::Error;
@@ -101,14 +101,6 @@ impl<'c> WalletClient<'c> {
 
         Ok((secret_tweak_key, peg_in_proof))
     }
-
-    pub fn create_pegout_output(
-        &self,
-        amount: bitcoin::Amount,
-        recipient: bitcoin::Address,
-    ) -> PegOut {
-        PegOut { recipient, amount }
-    }
 }
 
 type Result<T> = std::result::Result<T, WalletClientError>;
@@ -142,8 +134,10 @@ mod tests {
         FakeBitcoindRpc, FakeBitcoindRpcController,
     };
     use minimint_core::modules::wallet::config::WalletClientConfig;
-    use minimint_core::modules::wallet::db::UTXOKey;
-    use minimint_core::modules::wallet::{SpendableUTXO, Wallet};
+    use minimint_core::modules::wallet::db::{RoundConsensusKey, UTXOKey};
+    use minimint_core::modules::wallet::{
+        Feerate, PegOut, PegOutFees, RoundConsensus, SpendableUTXO, Wallet,
+    };
     use minimint_core::outcome::{OutputOutcome, TransactionStatus};
     use minimint_core::transaction::Transaction;
     use std::str::FromStr;
@@ -191,6 +185,14 @@ mod tests {
         ) -> crate::api::Result<IncomingContractOffer> {
             unimplemented!();
         }
+
+        async fn fetch_peg_out_fees(
+            &self,
+            _address: Address,
+            _amount: bitcoin::Amount,
+        ) -> crate::api::Result<Option<PegOutFees>> {
+            unimplemented!();
+        }
     }
 
     async fn new_mint_and_client() -> (
@@ -235,7 +237,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn create_output() {
         let (fed, client_context, btc_rpc) = new_mint_and_client().await;
-        let client = WalletClient {
+        let _client = WalletClient {
             context: client_context.borrow_with_module_config(|x| x),
             fee_consensus: FeeConsensus {
                 fee_coin_spend_abs: Amount::ZERO,
@@ -257,6 +259,16 @@ mod tests {
             };
 
             db.insert_entry(&UTXOKey(out_point), &utxo).unwrap();
+
+            db.insert_entry(
+                &RoundConsensusKey,
+                &RoundConsensus {
+                    block_height: 0,
+                    fee_rate: Feerate { sats_per_kvb: 0 },
+                    randomness_beacon: tweak,
+                },
+            )
+            .unwrap();
         });
 
         let addr = Address::from_str("msFGPqHVk8rbARMd69FfGYxwcboZLemdBi").unwrap();
@@ -266,7 +278,14 @@ mod tests {
             txid: Default::default(),
             out_idx: 0,
         };
-        let output = client.create_pegout_output(amount, addr.clone());
+        let output = PegOut {
+            recipient: addr.clone(),
+            amount,
+            fees: PegOutFees {
+                fee_rate: Feerate { sats_per_kvb: 0 },
+                total_weight: 0,
+            },
+        };
 
         // agree on output
         btc_rpc.set_block_height(100).await;

--- a/docs/database.md
+++ b/docs/database.md
@@ -40,7 +40,6 @@ The Database is split into different key spaces based on prefixing that can be u
 | Blocks                    | `0x30`   | block hash (32 bytes)                     | block height                              |
 | Our UTXOs                 | `0x31`   | OutPoint (32 bytes txid + 4 bytes output) | data necessary for spending               |
 | Round Consensus           | `0x32`   | none                                      | block height, fee rate, randomness beacon |
-| Queued PegOut             | `0x33`   | mint outpoint (40 bytes)                  | address, amount, pending since block      |
 | Unsigned transaction      | `0x34`   | bitcoin tx id (32 bytes)                  | PSBT                                      |
 | Pending transaction       | `0x35`   | bitcoin tx id (32 bytes)                  | consensus encoded tx, change tweak        |
 | Pending Peg Out Signature | `0x36`   | bitcoin tx id (32 bytes)                  | list of signatures (1 per input)          |
@@ -65,3 +64,4 @@ The Database is split into different key spaces based on prefixing that can be u
 | Outgoing Payment Claim    | `0x24` | contract id (sha256)               | `Transaction`                |
 | Outgoing Contract Account | `0x25` | contract id (sha256)               | `OutgoingContractAccount`    |
 | Confirmed Invoice         | `0x26` | contract id (sha256 payment hash)  | `ConfirmedInvoice`           |
+| Pending Coins             | `0x27` | mint tx id (sha256 payment hash)   | `Coins<SpendableCoin>`       |

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -19,31 +19,27 @@ use minimint_mint::{PartialSigResponse, PartiallySignedRequest};
 use minimint_wallet::WalletConsensusItem;
 use minimint_wallet::WalletConsensusItem::PegOutSignature;
 use mint_client::transaction::TransactionBuilder;
+use mint_client::ClientError;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn peg_in_and_peg_out_with_fees() {
-    const PEG_IN_AMOUNT: u64 = 5000;
-    const PEG_OUT_AMOUNT: u64 = 1200; // amount requires minted change
-
-    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await;
-    let after_peg_in = sats(PEG_IN_AMOUNT) - fed.fees.fee_peg_in_abs;
-    let after_peg_out = after_peg_in - sats(PEG_OUT_AMOUNT) - fed.fees.fee_peg_out_abs;
+    let peg_in_amount: u64 = 5000;
+    let peg_out_amount: u64 = 1200; // amount requires minted change
+    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await;
 
     let peg_in_address = user.client.get_new_pegin_address(rng());
-    let (proof, tx) = bitcoin.send_and_mine_block(&peg_in_address, Amount::from_sat(PEG_IN_AMOUNT));
+    let (proof, tx) = bitcoin.send_and_mine_block(&peg_in_address, Amount::from_sat(peg_in_amount));
     bitcoin.mine_blocks(fed.wallet.finalty_delay as u64);
     fed.run_consensus_epochs(1).await;
 
     user.client.peg_in(proof, tx, rng()).await.unwrap();
     fed.run_consensus_epochs(2).await; // peg in epoch + partial sigs epoch
-    user.assert_total_coins(after_peg_in).await;
+    user.assert_total_coins(sats(peg_in_amount)).await;
 
     let peg_out_address = bitcoin.get_new_address();
-    user.peg_out(PEG_OUT_AMOUNT, &peg_out_address).await;
-    fed.run_consensus_epochs(1).await;
+    let fees = user.peg_out(peg_out_amount, &peg_out_address).await;
+    fed.run_consensus_epochs(2).await; // peg-out tx + peg out signing epoch
 
-    bitcoin.mine_blocks(minimint_wallet::MIN_PEG_OUT_URGENCY as u64 + 1);
-    fed.run_consensus_epochs(2).await; // block height epoch + peg out signing epoch
     assert_matches!(
         fed.last_consensus_items().first(),
         Some(ConsensusItem::Wallet(PegOutSignature(_)))
@@ -52,11 +48,78 @@ async fn peg_in_and_peg_out_with_fees() {
     fed.broadcast_transactions().await;
     assert_eq!(
         bitcoin.mine_block_and_get_received(&peg_out_address),
-        sats(PEG_OUT_AMOUNT)
+        sats(peg_out_amount)
     );
-    user.assert_total_coins(after_peg_out).await;
-    let fees = fed.fees.fee_peg_in_abs + fed.fees.fee_peg_out_abs;
-    assert_eq!(fed.max_balance_sheet(), fees.milli_sat);
+    user.assert_total_coins(sats(peg_in_amount - peg_out_amount) - fees)
+        .await;
+    assert_eq!(fed.max_balance_sheet(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn peg_outs_are_rejected_if_fees_are_too_low() {
+    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await;
+    let peg_out_amount = Amount::from_sat(1000);
+    let peg_out_address = bitcoin.get_new_address();
+
+    fed.mine_and_mint(&user, &*bitcoin, sats(3000)).await;
+    let mut peg_out = user
+        .client
+        .fetch_peg_out_fees(peg_out_amount, peg_out_address.clone())
+        .await
+        .unwrap();
+
+    // Lower rate below FeeConsensus
+    peg_out.fees.fee_rate.sats_per_kvb = 10;
+    // TODO: return a better error message to clients
+    assert!(user.client.peg_out(peg_out, rng()).await.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn peg_outs_are_only_allowed_once_per_epoch() {
+    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await;
+    let address1 = bitcoin.get_new_address();
+    let address2 = bitcoin.get_new_address();
+
+    fed.mine_and_mint(&user, &*bitcoin, sats(5000)).await;
+    let _fees = user.peg_out(1000, &address1).await;
+    user.peg_out(1000, &address2).await;
+
+    fed.run_consensus_epochs(2).await;
+    fed.broadcast_transactions().await;
+
+    let received1 = bitcoin.mine_block_and_get_received(&address1);
+    let received2 = bitcoin.mine_block_and_get_received(&address2);
+
+    assert_eq!(received1 + received2, sats(1000));
+    // FIXME requires clients reissuing coins from failed transactions
+    // user.assert_total_coins(sats(5000 - 1000) - fees).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn peg_outs_must_wait_for_available_utxos() {
+    let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(10), sats(100), sats(1000)]).await;
+    let address1 = bitcoin.get_new_address();
+    let address2 = bitcoin.get_new_address();
+
+    fed.mine_and_mint(&user, &*bitcoin, sats(5000)).await;
+    user.peg_out(1000, &address1).await;
+
+    fed.run_consensus_epochs(2).await;
+    fed.broadcast_transactions().await;
+    assert_eq!(bitcoin.mine_block_and_get_received(&address1), sats(1000));
+
+    // The change UTXO is still finalizing
+    let response = user
+        .client
+        .fetch_peg_out_fees(Amount::from_sat(2000), address2.clone());
+    assert_matches!(response.await, Err(ClientError::PegOutWaitingForUTXOs));
+
+    bitcoin.mine_blocks(100);
+    fed.run_consensus_epochs(1).await;
+    user.peg_out(2000, &address2).await;
+    fed.run_consensus_epochs(2).await;
+    fed.broadcast_transactions().await;
+    assert_eq!(bitcoin.mine_block_and_get_received(&address2), sats(2000));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -143,7 +206,7 @@ async fn drop_peer_3_during_epoch(fed: &FederationTest) {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn drop_peers_who_dont_contribute_peg_out_psbts() {
-    let (fed, user, bitcoin, _, _) = fixtures(4, &[sats(100), sats(1000)]).await;
+    let (fed, user, bitcoin, _, _) = fixtures(4, &[sats(1), sats(10), sats(100), sats(1000)]).await;
     // FIXME coins cannot be fetched if peer is not in the epoch
     fed.mine_spendable_utxo(&user, &*bitcoin, Amount::from_sat(3000));
     fed.subset_peers(&[0, 1, 2])
@@ -156,9 +219,6 @@ async fn drop_peers_who_dont_contribute_peg_out_psbts() {
     // Ensure peer 0 who received the peg out request is in the next epoch
     fed.subset_peers(&[0, 1, 2]).run_consensus_epochs(1).await;
     fed.subset_peers(&[3]).run_consensus_epochs(1).await;
-    bitcoin.mine_blocks(fed.wallet.finalty_delay as u64);
-    bitcoin.mine_blocks(minimint_wallet::MIN_PEG_OUT_URGENCY as u64 + 1);
-    fed.run_consensus_epochs(1).await;
 
     fed.subset_peers(&[3]).override_proposal(vec![]);
     drop_peer_3_during_epoch(&fed).await;
@@ -169,7 +229,7 @@ async fn drop_peers_who_dont_contribute_peg_out_psbts() {
         sats(1000)
     );
     assert!(fed.subset_peers(&[0, 1, 2]).has_dropped_peer(3));
-    assert_eq!(fed.max_balance_sheet(), fed.fees.fee_peg_out_abs.milli_sat);
+    assert_eq!(fed.max_balance_sheet(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -500,29 +560,25 @@ async fn runs_consensus_if_tx_submitted() {
 #[tokio::test(flavor = "multi_thread")]
 async fn runs_consensus_if_new_block() {
     let (fed, user, bitcoin, _, _) = fixtures(2, &[sats(100), sats(1000)]).await;
-    fed.mine_and_mint(&user, &*bitcoin, sats(3000)).await;
-
-    let peg_out_address = bitcoin.get_new_address();
-    user.peg_out(1000, &peg_out_address).await;
+    let peg_in_address = user.client.get_new_pegin_address(rng());
+    bitcoin.mine_blocks(100);
+    let (proof, tx) = bitcoin.send_and_mine_block(&peg_in_address, Amount::from_sat(1000));
     fed.run_consensus_epochs(1).await;
 
-    // If epochs run before the blocks are mined, won't be able to peg-out
+    // If epochs run before the blocks are mined, user won't be able to peg-in
     join_all(vec![
         Either::Left(async {
             tokio::time::sleep(Duration::from_millis(500)).await;
             bitcoin.mine_blocks(fed.wallet.finalty_delay as u64);
-            bitcoin.mine_blocks(minimint_wallet::MIN_PEG_OUT_URGENCY as u64 + 1);
         }),
-        Either::Right(async { fed.run_consensus_epochs(2).await }),
+        Either::Right(async { fed.run_consensus_epochs(1).await }),
     ])
     .await;
 
-    fed.broadcast_transactions().await;
-    assert_eq!(
-        bitcoin.mine_block_and_get_received(&peg_out_address),
-        sats(1000)
-    );
-    assert_eq!(fed.max_balance_sheet(), fed.fees.fee_peg_out_abs.milli_sat);
+    user.client.peg_in(proof, tx, rng()).await.unwrap();
+    fed.run_consensus_epochs(2).await; // peg-in + blind sign
+    user.assert_total_coins(sats(1000)).await;
+    assert_eq!(fed.max_balance_sheet(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/ln-gateway/src/lib.rs
+++ b/ln-gateway/src/lib.rs
@@ -275,8 +275,13 @@ impl LnGateway {
         withdraw: WithdrawPayload,
     ) -> Result<TransactionId, LnGatewayError> {
         let rng = rand::rngs::OsRng::new().unwrap();
+        let peg_out = self
+            .federation_client
+            .fetch_peg_out_fees(withdraw.1, withdraw.0)
+            .await
+            .unwrap();
         self.federation_client
-            .peg_out(withdraw.1, withdraw.0, rng)
+            .peg_out(peg_out, rng)
             .await
             .map_err(LnGatewayError::ClientError)
     }

--- a/ln-gateway/src/lib.rs
+++ b/ln-gateway/src/lib.rs
@@ -277,7 +277,7 @@ impl LnGateway {
         let rng = rand::rngs::OsRng::new().unwrap();
         let peg_out = self
             .federation_client
-            .fetch_peg_out_fees(withdraw.1, withdraw.0)
+            .new_peg_out_with_fees(withdraw.1, withdraw.0)
             .await
             .unwrap();
         self.federation_client

--- a/minimint-core/src/outcome.rs
+++ b/minimint-core/src/outcome.rs
@@ -9,8 +9,6 @@ use crate::CoreError;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub enum TransactionStatus {
-    /// Errors indicate a failure in the API or the transaction was not found
-    Error(String),
     /// The rejected state is only recorded if the error happens after consensus is achieved on the
     /// transaction. This should happen only rarely, e.g. on double spends since a basic validity
     /// check is performed on transaction submission or on not having enough UTXOs to peg-out.
@@ -68,7 +66,6 @@ impl Final for OutputOutcome {
 impl Final for TransactionStatus {
     fn is_final(&self) -> bool {
         match self {
-            TransactionStatus::Error(_) => true,
             TransactionStatus::Rejected(_) => true,
             TransactionStatus::Accepted { outputs, .. } => outputs.iter().all(|out| out.is_final()),
         }

--- a/minimint-core/src/outcome.rs
+++ b/minimint-core/src/outcome.rs
@@ -9,10 +9,12 @@ use crate::CoreError;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
 pub enum TransactionStatus {
-    /// The error state is only recorded if the error happens after consensus is achieved on the
-    /// transaction. This should happen only rarely, e.g. on double spends since a basic validity
-    /// check is performed on transaction submission.
+    /// Errors indicate a failure in the API or the transaction was not found
     Error(String),
+    /// The rejected state is only recorded if the error happens after consensus is achieved on the
+    /// transaction. This should happen only rarely, e.g. on double spends since a basic validity
+    /// check is performed on transaction submission or on not having enough UTXOs to peg-out.
+    Rejected(String),
     /// The transaction was accepted and is now being processed
     Accepted {
         epoch: u64,
@@ -67,6 +69,7 @@ impl Final for TransactionStatus {
     fn is_final(&self) -> bool {
         match self {
             TransactionStatus::Error(_) => true,
+            TransactionStatus::Rejected(_) => true,
             TransactionStatus::Accepted { outputs, .. } => outputs.iter().all(|out| out.is_final()),
         }
     }

--- a/minimint-core/src/transaction.rs
+++ b/minimint-core/src/transaction.rs
@@ -63,7 +63,7 @@ impl TransactionItem for Output {
     fn amount(&self) -> Amount {
         match self {
             Output::Mint(coins) => coins.amount(),
-            Output::Wallet(peg_out) => peg_out.amount.into(),
+            Output::Wallet(peg_out) => (peg_out.amount + peg_out.fees.amount()).into(),
             Output::LN(minimint_ln::ContractOrOfferOutput::Contract(output)) => output.amount,
             Output::LN(minimint_ln::ContractOrOfferOutput::Offer(_)) => Amount::ZERO,
         }

--- a/minimint/src/config.rs
+++ b/minimint/src/config.rs
@@ -89,9 +89,9 @@ impl GenerateConfig for ServerConfig {
 
         let fee_consensus = FeeConsensus {
             fee_coin_spend_abs: minimint_api::Amount::ZERO,
-            fee_peg_in_abs: minimint_api::Amount::from_sat(1000),
+            fee_peg_in_abs: minimint_api::Amount::ZERO,
             fee_coin_issuance_abs: minimint_api::Amount::ZERO,
-            fee_peg_out_abs: minimint_api::Amount::from_sat(1000),
+            fee_peg_out_abs: minimint_api::Amount::ZERO,
             fee_contract_input: minimint_api::Amount::ZERO,
             fee_contract_output: minimint_api::Amount::ZERO,
         };

--- a/minimint/src/consensus/conflictfilter.rs
+++ b/minimint/src/consensus/conflictfilter.rs
@@ -90,10 +90,10 @@ where
                 }
             }
             if let Output::Wallet(_) = output {
-                if self.pegged_out {
-                    return Err(tx.clone());
+                match self.pegged_out {
+                    true => return Err(tx.clone()),
+                    false => self.pegged_out = true,
                 }
-                self.pegged_out = true;
             }
         }
         Ok(tx.clone())

--- a/minimint/src/db.rs
+++ b/minimint/src/db.rs
@@ -8,6 +8,7 @@ use std::fmt::Debug;
 pub const DB_PREFIX_PROPOSED_TRANSACTION: u8 = 0x01;
 pub const DB_PREFIX_ACCEPTED_TRANSACTION: u8 = 0x02;
 pub const DB_PREFIX_DROP_PEER: u8 = 0x03;
+pub const DB_PREFIX_REJECTED_TRANSACTION: u8 = 0x04;
 
 #[derive(Debug, Encodable, Decodable)]
 pub struct ProposedTransactionKey(pub TransactionId);
@@ -34,6 +35,15 @@ impl DatabaseKeyPrefixConst for AcceptedTransactionKey {
     const DB_PREFIX: u8 = DB_PREFIX_ACCEPTED_TRANSACTION;
     type Key = Self;
     type Value = AcceptedTransaction;
+}
+
+#[derive(Debug, Encodable, Decodable)]
+pub struct RejectedTransactionKey(pub TransactionId);
+
+impl DatabaseKeyPrefixConst for RejectedTransactionKey {
+    const DB_PREFIX: u8 = DB_PREFIX_REJECTED_TRANSACTION;
+    type Key = Self;
+    type Value = String;
 }
 
 #[derive(Debug, Encodable, Decodable)]

--- a/modules/minimint-wallet/src/db.rs
+++ b/modules/minimint-wallet/src/db.rs
@@ -1,6 +1,4 @@
-use crate::{
-    PendingPegOut, PendingTransaction, RoundConsensus, SpendableUTXO, UnsignedTransaction,
-};
+use crate::{PendingTransaction, RoundConsensus, SpendableUTXO, UnsignedTransaction};
 use bitcoin::{BlockHash, OutPoint, Txid};
 use minimint_api::db::DatabaseKeyPrefixConst;
 use minimint_api::encoding::{Decodable, Encodable};
@@ -9,7 +7,6 @@ use secp256k1::ecdsa::Signature;
 const DB_PREFIX_BLOCK_HASH: u8 = 0x30;
 const DB_PREFIX_UTXO: u8 = 0x31;
 const DB_PREFIX_ROUND_CONSENSUS: u8 = 0x32;
-const DB_PREFIX_PEDNING_PEGOUT: u8 = 0x33;
 const DB_PREFIX_UNSIGNED_TRANSACTION: u8 = 0x34;
 const DB_PREFIX_PENDING_TRANSACTION: u8 = 0x35;
 const DB_PREFIX_PEG_OUT_TX_SIG_CI: u8 = 0x36;
@@ -48,24 +45,6 @@ impl DatabaseKeyPrefixConst for RoundConsensusKey {
     const DB_PREFIX: u8 = DB_PREFIX_ROUND_CONSENSUS;
     type Key = Self;
     type Value = RoundConsensus;
-}
-
-#[derive(Clone, Debug, Encodable, Decodable)]
-pub struct PendingPegOutKey(pub minimint_api::OutPoint);
-
-impl DatabaseKeyPrefixConst for PendingPegOutKey {
-    const DB_PREFIX: u8 = DB_PREFIX_PEDNING_PEGOUT;
-    type Key = Self;
-    type Value = PendingPegOut;
-}
-
-#[derive(Clone, Debug, Encodable, Decodable)]
-pub struct PendingPegOutPrefixKey;
-
-impl DatabaseKeyPrefixConst for PendingPegOutPrefixKey {
-    const DB_PREFIX: u8 = DB_PREFIX_PEDNING_PEGOUT;
-    type Key = PendingPegOutKey;
-    type Value = PendingPegOut;
 }
 
 #[derive(Clone, Debug, Encodable, Decodable)]

--- a/modules/minimint-wallet/src/lib.rs
+++ b/modules/minimint-wallet/src/lib.rs
@@ -101,14 +101,6 @@ pub struct SpendableUTXO {
     pub amount: bitcoin::Amount,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Encodable, Decodable)]
-pub struct PendingPegOut {
-    destination: Script,
-    #[serde(with = "bitcoin::util::amount::serde::as_sat")]
-    amount: bitcoin::Amount,
-    pending_since_block: u32,
-}
-
 /// A peg-out tx that is ready to be broadcast with a tweak for the change UTXO
 #[derive(Clone, Debug, Encodable, Decodable)]
 pub struct PendingTransaction {

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -23,7 +23,6 @@ $FM_MINT_CLIENT fetch
 PEG_OUT_ADDR="$($FM_BTC_CLIENT getnewaddress)"
 $FM_MINT_CLIENT peg-out $PEG_OUT_ADDR 500
 sleep 5 # FIXME wait for tx to be included
-mine_blocks 120
 await_block_sync
 until [ "$($FM_BTC_CLIENT getreceivedbyaddress $PEG_OUT_ADDR 0)" == "0.00000500" ]; do
   sleep $POLL_INTERVAL


### PR DESCRIPTION
Stops the fed from crashing due to peg-outs (fixes step 1 in #233)
- Peg-outs now only can happen once per epoch and only one peg-out is allowed per UTXO.
- Broadcasts are immediate after a peg-out is signed.
- Fees are exact and determined by the estimated min. sat/byte required by `FeeConsensus` (target confirmation time = 10 blocks) and the calculated transaction weight (no more profits/losses).
- Rather than always returning 404 if a tx failed the fed will store and return the `TransactionStatus::Rejected`, allowing clients react to tx errors.
- Stores pending coins and will reissue them in `reissue_pending_coins` if a tx is rejected (fixes #35)