### PR TITLE
client: concurrent requests take 2

### DIFF
--- a/client/cli/src/bin/mint-rpc-client.rs
+++ b/client/cli/src/bin/mint-rpc-client.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use minimint_api::PeerId;
-use mint_client::api::WsFederationApi;
+use mint_client::api::FederationMember;
 
 #[derive(Parser)]
 struct ApiCall {
@@ -14,8 +14,8 @@ struct ApiCall {
 async fn main() {
     let call = ApiCall::parse();
     let arg: serde_json::Value = serde_json::from_str(&call.arg).unwrap();
-    let api = WsFederationApi::new(0, vec![(PeerId::from(0), call.url)]).await;
-    let response: serde_json::Value = api.request(&call.method, arg).await.unwrap();
+    let api = FederationMember::new(PeerId::from(0), call.url);
+    let response: serde_json::Value = api.request(&call.method, &[arg]).await.unwrap();
     let formatted = serde_json::to_string_pretty(&response).unwrap();
     print!("{}", formatted);
 }

--- a/client/client-lib/src/api.rs
+++ b/client/client-lib/src/api.rs
@@ -138,7 +138,7 @@ pub struct WsFederationApi<C = WsClient> {
 }
 
 #[derive(Debug)]
-struct FederationMember<C> {
+pub struct FederationMember<C> {
     url: String,
     peer_id: PeerId,
     client: RwLock<Option<C>>,
@@ -237,6 +237,16 @@ impl<C> WsFederationApi<C> {
                 })
                 .collect(),
             max_evil,
+        }
+    }
+}
+
+impl FederationMember<WsClient> {
+    pub fn new(peer_id: PeerId, url: String) -> Self {
+        Self {
+            url,
+            peer_id,
+            client: RwLock::new(None),
         }
     }
 }


### PR DESCRIPTION
CI was failing because the peers do not return same output. We only checked for `max_evil + 1` successes. Now we check for `max_evil + 1` same outputs.

TODO: 
- [x] fix error in mint-rpc-client

related #275 #208 