### PR TITLE
Fix bitcoind 23.0 install on aarch64

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,7 @@
 let
   nix-pinned = builtins.fetchTarball {
     name = "nixos-22.05";
-    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/22.05.tar.gz";
-    sha256 = "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik";
+    url = "https://github.com/NixOS/nixpkgs/archive/bd95ace2d31564c0caceda68a8c2ec1b97f7116e.tar.gz";
   };
 in
 { pkgs ? import (nix-pinned) {}}:


### PR DESCRIPTION
Thanks @justinmoon for the debugging session.

This fixes the build of bitcoind `23.0` by using the standard bitcoind package after the fix in nixos/nixpkgs#179795 was merged.