### PR TITLE
refactor to move PeerConnections to api

### DIFF
--- a/minimint-api/src/lib.rs
+++ b/minimint-api/src/lib.rs
@@ -17,6 +17,7 @@ pub mod config;
 pub mod db;
 pub mod encoding;
 pub mod module;
+pub mod net;
 pub mod task;
 
 hash_newtype!(

--- a/minimint-api/src/net/mod.rs
+++ b/minimint-api/src/net/mod.rs
@@ -1,0 +1,1 @@
+pub mod peers;

--- a/minimint-api/src/net/peers.rs
+++ b/minimint-api/src/net/peers.rs
@@ -1,0 +1,47 @@
+use async_trait::async_trait;
+use minimint_api::PeerId;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+/// Owned [`PeerConnections`] trait object type
+pub type AnyPeerConnections<M> = Box<dyn PeerConnections<M> + Send + Unpin + 'static>;
+
+/// Connection manager that tries to keep connections open to all peers
+///
+/// Production implementations of this trait have to ensure that:
+/// * Connections to peers are authenticated and encrypted
+/// * Messages are received exactly once and in the order they were sent
+/// * Connections are reopened when closed
+/// * Messages are cached in case of short-lived network interruptions and resent on reconnect, this
+///   avoids the need to rejoin the consensus, which is more tricky.
+///
+/// In case of longer term interruptions the message cache has to be dropped to avoid DoS attacks.
+/// The thus disconnected peer will need to rejoin the consensus at a later time.  
+#[async_trait]
+pub trait PeerConnections<T>
+where
+    T: Serialize + DeserializeOwned + Unpin + Send,
+{
+    /// Send a message to a specific peer.
+    ///
+    /// The message is sent immediately and cached if the peer is reachable and only cached
+    /// otherwise.
+    async fn send(&mut self, target: PeerId, msg: T);
+
+    /// Send a message to all peers
+    async fn send_all(&mut self, msg: T);
+
+    /// Await receipt of a message from any connected peer.
+    async fn receive(&mut self) -> (PeerId, T);
+
+    /// Removes a peer connection in case of misbehavior
+    async fn ban_peer(&mut self, peer: PeerId);
+
+    /// Converts the struct to a `PeerConnection` trait object
+    fn to_any(self) -> AnyPeerConnections<T>
+    where
+        Self: Sized + Send + Unpin + 'static,
+    {
+        Box::new(self)
+    }
+}


### PR DESCRIPTION
Moving `PeerConnections` to the `api` module is necessary for generating the distributed config #298