### PR TITLE
move the cleanup function to lib

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+
+source ./scripts/lib.sh
 echo "Run with 'source ./scripts/build.sh [fed_size] [dir]"
 
 # allow for overriding arguments
@@ -45,10 +47,4 @@ alias mint_rpc_client="\$FM_MINT_RPC_CLIENT"
 alias clientd="\$FM_CLIENTD"
 alias clientd-cli="\$FM_CLIENTD_CLI"
 
-# Function for killing processes stored in FM_PID_FILE
-function kill_minimint_processes {
-  kill $(cat $FM_PID_FILE | sed '1!G;h;$!d') #sed reverses the order here
-  pkill "ln_gateway";
-  rm $FM_PID_FILE
-}
 trap kill_minimint_processes EXIT

--- a/scripts/cli-test.sh
+++ b/scripts/cli-test.sh
@@ -5,8 +5,6 @@ set -euxo pipefail
 export RUST_LOG=info
 export PEG_IN_AMOUNT=99999
 
-source ./scripts/lib.sh
-source ./scripts/build.sh
 source ./scripts/setup-tests.sh
 ./scripts/start-fed.sh
 ./scripts/pegin.sh # peg in user

--- a/scripts/latency-test.sh
+++ b/scripts/latency-test.sh
@@ -8,7 +8,7 @@ export RUST_LOG=error,ln_gateway=off
 export PEG_IN_AMOUNT=99999
 
 source ./scripts/build.sh $FM_FED_SIZE
-source ./scripts/setup-tests.sh
+source ./scripts/setup-tests.sh #sources lib.sh
 ./scripts/start-fed.sh
 ./scripts/pegin.sh
 

--- a/scripts/latency-test.sh
+++ b/scripts/latency-test.sh
@@ -7,8 +7,7 @@ ITERATIONS=${2:-5}
 export RUST_LOG=error,ln_gateway=off
 export PEG_IN_AMOUNT=99999
 
-source ./scripts/build.sh $FM_FED_SIZE
-source ./scripts/setup-tests.sh #sources lib.sh
+source ./scripts/setup-tests.sh $FM_FED_SIZE
 ./scripts/start-fed.sh
 ./scripts/pegin.sh
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -33,3 +33,10 @@ function await_server_on_port() {
       sleep $POLL_INTERVAL
   done
 }
+
+# Function for killing processes stored in FM_PID_FILE
+function kill_minimint_processes {
+  kill $(cat $FM_PID_FILE | sed '1!G;h;$!d') #sed reverses the order here
+  pkill "ln_gateway";
+  rm $FM_PID_FILE
+}

--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -4,8 +4,7 @@
 set -euxo pipefail
 export RUST_LOG=info
 
-source ./scripts/build.sh
-source ./scripts/setup-tests.sh #sources lib.sh
+source ./scripts/setup-tests.sh
 
 export MINIMINT_TEST_REAL=1
 cargo test --release -p minimint-tests -- --test-threads=1

--- a/scripts/rust-tests.sh
+++ b/scripts/rust-tests.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 export RUST_LOG=info
 
 source ./scripts/build.sh
-source ./scripts/setup-tests.sh
+source ./scripts/setup-tests.sh #sources lib.sh
 
 export MINIMINT_TEST_REAL=1
 cargo test --release -p minimint-tests -- --test-threads=1

--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -2,7 +2,9 @@
 
 set -u
 
-source ./scripts/lib.sh
+FM_FED_SIZE=${1:-4}
+
+source ./scripts/build.sh $FM_FED_SIZE
 
 # Starts Bitcoin and 2 LN nodes, opening a channel between the LN nodes
 POLL_INTERVAL=1


### PR DESCRIPTION
Other scripts might wan't to use that cleanup logic too so it makes sense to put it into `lib.sh`
the `trap` remains in `build.sh` though because we want scripts to be able to `source lib.sh` and execute to finish without cleaning up everything (`pegin.sh` for example)