### PR TITLE
make (server) db_path configurable

### DIFF
--- a/minimint/src/bin/server.rs
+++ b/minimint/src/bin/server.rs
@@ -11,6 +11,7 @@ use tracing_subscriber::Layer;
 #[derive(Parser)]
 pub struct ServerOpts {
     pub cfg_path: PathBuf,
+    pub db_path: PathBuf,
     #[cfg(feature = "telemetry")]
     #[clap(long)]
     pub with_telemetry: bool,
@@ -46,7 +47,8 @@ async fn main() {
     }
 
     let cfg: ServerConfig = load_from_file(&opts.cfg_path);
-    run_minimint(cfg).await;
+    let db_path = opts.db_path;
+    run_minimint(cfg, db_path).await;
 
     #[cfg(feature = "telemetry")]
     opentelemetry::global::shutdown_tracer_provider();

--- a/minimint/src/config.rs
+++ b/minimint/src/config.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
 use crate::net::connect::TlsConfig;
-use std::path::PathBuf;
 use tokio_rustls::rustls;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -33,8 +32,6 @@ pub struct ServerConfig {
     pub hbbft_sks: hbbft::crypto::serde_impl::SerdeSecret<hbbft::crypto::SecretKeyShare>,
     #[serde(with = "serde_binary_human_readable")]
     pub hbbft_pk_set: hbbft::crypto::PublicKeySet,
-
-    pub db_path: PathBuf,
 
     pub wallet: WalletConfig,
     pub mint: MintConfig,
@@ -126,7 +123,6 @@ impl GenerateConfig for ServerConfig {
                     hbbft_sk: SerdeSecret(netinf.secret_key().clone()),
                     hbbft_sks: SerdeSecret(netinf.secret_key_share().unwrap().clone()),
                     hbbft_pk_set: netinf.public_key_set().clone(),
-                    db_path: format!("cfg/mint-{}.db", id).into(),
                     wallet: wallet_server_cfg[&id].clone(),
                     mint: mint_server_cfg[&id].clone(),
                     ln: ln_server_cfg[&id].clone(),

--- a/scripts/start-fed.sh
+++ b/scripts/start-fed.sh
@@ -4,10 +4,8 @@
 set -euxo pipefail
 SKIPPED_SERVERS=${SKIPPED_SERVERS:-0}
 
-# FIXME: make db path configurable to avoid cd-ing here
 # Start the federation members inside the temporary directory
-cd $FM_CFG_DIR
 for ((ID=SKIPPED_SERVERS; ID<FM_FED_SIZE; ID++)); do
   echo "starting mint $ID"
-  ( ($FM_BIN_DIR/server $FM_CFG_DIR/server-$ID.json 2>&1 & echo $! >&3 ) 3>>$FM_PID_FILE | sed -e "s/^/mint $ID: /" ) &
+  ( ($FM_BIN_DIR/server $FM_CFG_DIR/server-$ID.json $FM_CFG_DIR/mint-$ID.db 2>&1 & echo $! >&3 ) 3>>$FM_PID_FILE | sed -e "s/^/mint $ID: /" ) &
 done


### PR DESCRIPTION
Addresses #220 
Removed `db_path` from the `ServerConfig` struct where it was always set to `cfg/mint-id.db` previously