### PR TITLE
allows for single member federations

### DIFF
--- a/crypto/tbs/src/lib.rs
+++ b/crypto/tbs/src/lib.rs
@@ -180,6 +180,11 @@ where
     if points.len() < threshold {
         panic!("Not enough signature shares");
     }
+
+    if points.len() == 1 {
+        return BlindedSignature(points.first().unwrap().1.to_affine());
+    }
+
     let bsig: G1Projective = poly::interpolate_zero(points.into_iter());
     BlindedSignature(bsig.to_affine())
 }
@@ -211,6 +216,10 @@ impl Aggregatable for Vec<PublicKeyShare> {
     type Aggregate = AggregatePublicKey;
 
     fn aggregate(&self, threshold: usize) -> Self::Aggregate {
+        if self.len() == 1 {
+            return AggregatePublicKey(self.first().unwrap().0);
+        }
+
         let elements = self
             .iter()
             .enumerate()

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -601,3 +601,10 @@ async fn unbalanced_transactions_get_rejected() {
     // TODO return a more useful error
     assert!(response.is_err());
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_have_federations_with_one_peer() {
+    let (fed, user, bitcoin, _, _) = fixtures(1, &[sats(100), sats(1000)]).await;
+    fed.mine_and_mint(&user, &*bitcoin, sats(1000)).await;
+    user.assert_total_coins(sats(1000)).await;
+}


### PR DESCRIPTION
Fixes #311 - to allow single-member federations, particularly for people who want to evaluate Fedimint themselves before putting in the effort of organizing a federation.

There is a Rust integration test, but also running `cli.test.sh` with fed size of 1 works which should test all modules.

@wiredhikari This might also help you run the nix module because you could run without any other peers.  Although for production users will need the option to pass in TLS configs for the other peers.