### PR TITLE
Fixtures wait 100 ms for federation to start before starting gateway

### DIFF
--- a/integrationtests/tests/fixtures/mod.rs
+++ b/integrationtests/tests/fixtures/mod.rs
@@ -630,6 +630,7 @@ impl FederationTest {
                 cfg.clone(),
                 minimint.consensus.clone(),
             ));
+            minimint_api::task::sleep(Duration::from_millis(100)).await; // wait for servers to start
 
             Rc::new(RefCell::new(ServerTest {
                 minimint,


### PR DESCRIPTION
Fixes [this intermittant test failure](https://github.com/fedimint/minimint/runs/7658393957?check_suite_focus=true).

Is there a better way?