### PR TITLE
Change LnClient::create_outgoing_output to be sync instead of async

### DIFF
--- a/client/client-lib/src/lib.rs
+++ b/client/client-lib/src/lib.rs
@@ -441,16 +441,14 @@ impl Client<UserClientConfig> {
         let consensus_height = self.context.api.fetch_consensus_block_height().await?;
         let absolute_timelock = consensus_height + TIMELOCK;
 
-        let contract = self
-            .ln_client()
-            .create_outgoing_output(
-                batch.transaction(),
-                invoice,
-                &gateway,
-                absolute_timelock as u32,
-                &mut rng,
-            )
-            .await?;
+        let contract = self.ln_client().create_outgoing_output(
+            batch.transaction(),
+            invoice,
+            &gateway,
+            absolute_timelock as u32,
+            &mut rng,
+        )?;
+
         let contract_id = match &contract {
             ContractOrOfferOutput::Contract(c) => c.contract.contract_id(),
             ContractOrOfferOutput::Offer(_) => {

--- a/client/client-lib/src/ln/mod.rs
+++ b/client/client-lib/src/ln/mod.rs
@@ -36,7 +36,7 @@ pub struct LnClient<'c> {
 impl<'c> LnClient<'c> {
     /// Create an output that incentivizes a Lighning gateway to pay an invoice for us. It has time
     /// till the block height defined by `timelock`, after that we can claim our money back.
-    pub async fn create_outgoing_output<'a>(
+    pub fn create_outgoing_output<'a>(
         &'a self,
         mut batch: BatchTx<'a>,
         invoice: Invoice,
@@ -352,8 +352,8 @@ mod tests {
                 timelock,
                 &mut rng,
             )
-            .await
             .unwrap();
+
         client_context.db.apply_batch(batch).unwrap();
 
         let contract = match &output {


### PR DESCRIPTION
All invocations of LnClient::create_outgoing_output simply await the response. This PR modifies the method declaration to be synchronous instead of asynchronous so that callers don't need to await the result.