### PR TITLE
Update README command to run integration tests

### DIFF
--- a/integrationtests/README.md
+++ b/integrationtests/README.md
@@ -32,7 +32,7 @@ Tests run by default with fake Lightning and Bitcoin services for fast concurren
 To run the tests in parallel against fake versions of Lightning and Bitcoin:
 ```shell
 export MINIMINT_TEST_REAL=0
-cargo test -p minimint
+cargo test -p minimint-tests
 ```
 
 When integration tests run they will output a debug log for each epoch:


### PR DESCRIPTION
Currently this just runs tests in the main `minimint` crate. I think this is leftover from when the integration tests lived inside `minimint` crate. Now they have their own crate.