### PR TITLE
Create new socket in tmuxinator to avoid using any existing session

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -1,5 +1,6 @@
 name: fedimint-dev
 root: .
+socket_name: fedimint-dev
 pre_window:
   - source .tmpenv
   - alias ln1="\$FM_LN1"

--- a/scripts/tmuxinator.sh
+++ b/scripts/tmuxinator.sh
@@ -14,7 +14,7 @@ echo "Running in temporary directory $FM_TEST_DIR"
 env | sed -En 's/(FM_[^=]*).*/\1/gp' | while read var; do printf 'export %s=%q\n' "$var" "${!var}"; done > .tmpenv
 
 tmuxinator local
-tmux kill-session -t fedimint-dev || true
+tmux -L fedimint-dev kill-session -t fedimint-dev || true
 pkill bitcoind
 pkill lightningd
 


### PR DESCRIPTION
I'm just getting started trying out Fedimint but I got stuck because tmuxinator didn't play nice with my tmux session I already had running using the `fish` default shell. This PR creates a `fedimint-dev` socket so a separate session using `bash` as the default shell is still possible in my case.