### PR TITLE
ln-gateway: allow CORS

### DIFF
--- a/ln-gateway/Cargo.toml
+++ b/ln-gateway/Cargo.toml
@@ -27,3 +27,4 @@ sled = "0.34.6"
 thiserror = "1.0.30"
 tracing = { version = "0.1.26", default-features = false, features= ["log", "attributes", "std"] }
 tokio = {version = "1.0", features = ["full"]}
+tower-http = { version = "0.3.4", features = ["cors"] }

--- a/ln-gateway/src/webserver.rs
+++ b/ln-gateway/src/webserver.rs
@@ -2,6 +2,7 @@ use axum::{routing::post, Extension, Json, Router};
 
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+use tower_http::cors::CorsLayer;
 use tracing::{debug, instrument};
 
 use crate::GatewayRequestInner;
@@ -33,7 +34,8 @@ pub async fn pay_invoice(
 pub async fn run_webserver(sender: mpsc::Sender<GatewayRequest>) -> axum::response::Result<()> {
     let app = Router::new()
         .route("/pay_invoice", post(pay_invoice))
-        .layer(Extension(sender));
+        .layer(Extension(sender))
+        .layer(CorsLayer::permissive());
 
     axum::Server::bind(&"127.0.0.1:8080".parse().unwrap())
         .serve(app.into_make_service())


### PR DESCRIPTION
Inside a web browser, CORS is need for client to connect ln-gateway because
they are not hosted on the same orgin.