### PR TITLE
Add .dockerignore file.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Ignore cargo build directory.
+target


### PR DESCRIPTION
Ignore cargo target build directory when adding files to docker image.