### PR TITLE
Added finalty_delay to pegin.sh & fixed spelling

### DIFF
--- a/docs/wallet_module.md
+++ b/docs/wallet_module.md
@@ -19,7 +19,7 @@ Using a public key tweak instead of querying the federation for a new address av
 ### Pegging In - Federation
 - [Wallet::validate_input](../modules/minimint-wallet/src/lib.rs) - verifies that the `PegInProof` is in a block and is spendable by the federation's multisig.
 - [Wallet::apply_input](../modules/minimint-wallet/src/lib.rs) - stores the `SpendableUTXO` containing the transaction details and tweak key in the federation's wallet database.
-- [Wallet::begin_consensus_epoch](../modules/minimint-wallet/src/lib.rs) - determines the `RoundConsensus` containing the consensus block height which is delayed by a configurable `finalty_delay` of 10 blocks after which peg-ins accepted.
+- [Wallet::begin_consensus_epoch](../modules/minimint-wallet/src/lib.rs) - determines the `RoundConsensus` containing the consensus block height which is delayed by a configurable `finality_delay` of 10 blocks after which peg-ins accepted.
 
 ### Pegging Out - User Client
 - [Client::new_peg_out_with_fees](../client/client-lib/src/lib.rs) - creates a new `PegOut` for users by requesting the current peg-out fees from the fed's wallet API which is estimated based on the on-chain size of the transaction and the sats/byte to confirm in a `CONFIRMATION_TARGET` of 10 blocks.

--- a/integrationtests/tests/tests.rs
+++ b/integrationtests/tests/tests.rs
@@ -30,7 +30,7 @@ async fn peg_in_and_peg_out_with_fees() {
 
     let peg_in_address = user.client.get_new_pegin_address(rng());
     let (proof, tx) = bitcoin.send_and_mine_block(&peg_in_address, Amount::from_sat(peg_in_amount));
-    bitcoin.mine_blocks(fed.wallet.finalty_delay as u64);
+    bitcoin.mine_blocks(fed.wallet.finality_delay as u64);
     fed.run_consensus_epochs(1).await;
 
     user.client.peg_in(proof, tx, rng()).await.unwrap();
@@ -569,7 +569,7 @@ async fn runs_consensus_if_new_block() {
     join_all(vec![
         Either::Left(async {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            bitcoin.mine_blocks(fed.wallet.finalty_delay as u64);
+            bitcoin.mine_blocks(fed.wallet.finality_delay as u64);
         }),
         Either::Right(async { fed.run_consensus_epochs(1).await }),
     ])

--- a/modules/minimint-wallet/src/config.rs
+++ b/modules/minimint-wallet/src/config.rs
@@ -14,7 +14,7 @@ pub struct WalletConfig {
     pub peg_in_descriptor: PegInDescriptor,
     pub peer_peg_in_keys: BTreeMap<PeerId, CompressedPublicKey>,
     pub peg_in_key: secp256k1::SecretKey,
-    pub finalty_delay: u32,
+    pub finality_delay: u32,
     pub default_fee: Feerate,
     pub btc_rpc_address: String,
     pub btc_rpc_user: String,
@@ -68,7 +68,7 @@ impl GenerateConfig for WalletConfig {
                         .map(|(peer_id, (_, pk))| (*peer_id, CompressedPublicKey { key: *pk }))
                         .collect(),
                     peg_in_key: *sk,
-                    finalty_delay: 10,
+                    finality_delay: 10,
                     default_fee: Feerate { sats_per_kvb: 1000 },
                     btc_rpc_address: "127.0.0.1:18443".to_string(),
                     btc_rpc_user: "bitcoin".to_string(),

--- a/modules/minimint-wallet/src/lib.rs
+++ b/modules/minimint-wallet/src/lib.rs
@@ -742,7 +742,7 @@ impl Wallet {
 
     pub async fn target_height(&self) -> u32 {
         let our_network_height = self.btc_rpc.get_block_height().await as u32;
-        our_network_height.saturating_sub(self.cfg.finalty_delay)
+        our_network_height.saturating_sub(self.cfg.finality_delay)
     }
 
     pub fn consensus_height(&self) -> Option<u32> {

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -16,8 +16,8 @@ function open_channel() {
 }
 
 function await_block_sync() {
-  FINALTY_DELAY=$(cat $FM_CFG_DIR/server-0.json | jq -r '.wallet.finalty_delay')
-  EXPECTED_BLOCK_HEIGHT="$(( $($FM_BTC_CLIENT getblockchaininfo | jq -r '.blocks') - $FINALTY_DELAY ))"
+  FINALITY_DELAY=$(cat $FM_CFG_DIR/server-0.json | jq -r '.wallet.finality_delay')
+  EXPECTED_BLOCK_HEIGHT="$(( $($FM_BTC_CLIENT getblockchaininfo | jq -r '.blocks') - $FINALITY_DELAY ))"
   $FM_MINT_CLIENT wait-block-height $EXPECTED_BLOCK_HEIGHT
 }
 

--- a/scripts/pegin.sh
+++ b/scripts/pegin.sh
@@ -11,7 +11,8 @@ POLL_INTERVAL=1
 PEG_IN_AMOUNT=${PEG_IN_AMOUNT:-$1}
 USE_GATEWAY=${2:-0}
 
-echo "Pegging in $PEG_IN_AMOUNT"
+FINALITY_DELAY=$(cat $FM_CFG_DIR/server-0.json | jq -r '.wallet.finality_delay')
+echo "Pegging in $PEG_IN_AMOUNT with confirmation in $FINALITY_DELAY blocks"
 
 # Get a peg-in address, which is derived from the federation's descriptor in which every key was tweaked with the same
 # random value only known to our client.


### PR DESCRIPTION
These changes add the reporting of `finality_delay` to the output from `scripts/pegin.sh`. Additionally, the spelling was corrected from `finalty_delay`. This addresses issue [#216](https://github.com/fedimint/minimint/issues/216).