### PR TITLE
minimint-tests uses dev-dependencies

### DIFF
--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 name = "minimint-tests"
 path = "tests/tests.rs"
 
-[dependencies]
+[dev-dependencies]
 assert_matches = "1.5.0"
 async-trait = "0.1.42"
 bitcoin = "0.28.1"


### PR DESCRIPTION
Without this, `udeps` (added to CI in #336) will report all the dependencies of `minimint-tests` as unused because they are only used in testing, causing CI to fail. CI is currently failing on master for this reason, but I don't understand why #336 passed in review ...