### PR TITLE
Run nix-ci on buildjet

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   lint:
     name: "Lint"
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v3
 
@@ -33,7 +33,7 @@ jobs:
 
   build:
     name: "Build"
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
I wasn't aware of buildjet when I initially created it.