### PR TITLE
Remove dummy `[lib]` from `integrationtests`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,16 +83,17 @@
         # all the dependencies (as dir) to help limit the
         # amount of things that need to rebuild when some
         # file change
-        pkg = { name, dir, extraDirs ? [ ] }: rec {
+        pkg = { name ? null, dir, extraDirs ? [ ] }: rec {
           package = craneLib.buildPackage (commonArgs // {
             cargoArtifacts = workspaceDeps;
-            pname = name;
 
             src = filterModules ([ dir ] ++ extraDirs) ./.;
 
-            cargoExtraArgs = "--bin ${name}";
             # if needed we will check the whole workspace at once with `workspaceAll`
             doCheck = false;
+          } // lib.optionalAttrs (name != null) {
+            pname = name;
+            cargoExtraArgs = "--bin ${name}";
           });
         };
 
@@ -180,7 +181,6 @@
         };
 
         minimint-tests = pkg {
-          name = "minimint-tests";
           dir = "integrationtests";
           extraDirs = [
             "client/cli"

--- a/integrationtests/Cargo.toml
+++ b/integrationtests/Cargo.toml
@@ -3,10 +3,6 @@ name = "minimint-tests"
 version = "0.1.0"
 edition = "2018"
 
-[lib]
-name = "minimint_tests"
-path = "src/main.rs"
-
 [[test]]
 name = "minimint-tests"
 path = "tests/tests.rs"

--- a/integrationtests/src/main.rs
+++ b/integrationtests/src/main.rs
@@ -1,3 +1,0 @@
-pub fn main() {
-    // just here so the building system has a build target in this package
-}


### PR DESCRIPTION
It was only neccessary because I didn't know better how to do it,
and now I've got some help:

https://github.com/ipetkov/crane/discussions/59#discussioncomment-3370974